### PR TITLE
feat: rebuild audio engine with Tone.js and game state events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,11 @@ Baseball Scores displays live MLB games and (eventually) maps them to generative
 ```
 MLB StatsAPI → Next.js API Route (1s cache) → useGamePolling → Zustand Store → React Components
                                                                       ↓
-                                                                Audio Engine
-                                                             (hello-world sine tone)
+                                                              store.subscribe()
+                                                                      ↓
+                                                        diffGameEvents(prev, next)
+                                                                      ↓
+                                                          SoundBank → Tone.Gain → speakers
 ```
 
 ### Key Directories
@@ -30,7 +33,7 @@ MLB StatsAPI → Next.js API Route (1s cache) → useGamePolling → Zustand Sto
 - `src/store/` - Zustand store for game state management
 - `src/utils/` - `normalizeGame.js` — converts MLB API responses to internal format
 - `src/hooks/` - `useGamePolling` for data fetching
-- `src/audio/` - Elementary Audio engine (hello-world: sine tone when game selected)
+- `src/audio/` - Tone.js audio engine (event-driven sounds on game state changes)
 - `src/services/` - API client (`fetchGames`)
 
 ### Routing (Next.js App Router)
@@ -58,24 +61,30 @@ All pages use `'use client'` — the app is fully client-rendered.
 - Single function `normalizeGame(raw)` extracting from schedule+linescore hydration
 - No separate validation or change detection — change detection is built into `ingestGames`
 
-### Audio Architecture (Elementary Audio)
+### Audio Architecture (Tone.js)
 
-Hello-world audio engine proving Elementary Audio works end-to-end with the store.
+Event-driven audio engine that plays sounds in response to game state changes. Subscribes to the Zustand store and diffs the active game object on each update.
 
 **Public API (`src/audio/index.js`):**
-- `connect(store)` - Initialize AudioContext + WebRenderer, subscribe to store
-- `disconnect()` - Cleanup
-- `pause()` / `resume()` - Suspend/resume AudioContext
+- `connect(store)` - Initialize Tone.js, create SoundBank, subscribe to store
+- `disconnect()` - Cleanup all synths and subscriptions
+- `pause()` / `resume()` - Mute/unmute master gain (scoped, not global)
 - `setMasterVolume(0-1)` - Gain control
 - `isConnected()` - Check status
 
-**Behavior:** Game selected → 440Hz sine tone. No game → silence. No interpreter, layers, or effects yet.
+**Event flow:** Store update → `diffGameEvents(prev, next)` → `GameEvent[]` → `SoundBank.play*()`
+
+**Sound events:** runScored (arpeggio), outRecorded (percussive hit), inningChange (chime), runnerAdvance (pitched blip), statusChange (swell/resolution), strike (high tick), ball (low tick)
+
+**Audio connects on first game click** in MainLayout (satisfies browser AudioContext user-gesture requirement).
 
 **Structure:**
 ```
 src/audio/
-├── index.js    # Public API
-└── engine.js   # AudioEngine class (singleton)
+├── index.js           # Public API (unchanged surface)
+├── engine.js          # AudioEngine class (singleton, Tone.js)
+├── diffGameEvents.js  # Pure function: (prev, next) → GameEvent[]
+└── sounds.js          # SoundBank class: synth lifecycle + trigger methods
 ```
 
 ## Code Style

--- a/TODOS.md
+++ b/TODOS.md
@@ -15,3 +15,51 @@
 **Depends on:** Realtime state reliability PR (seq ordering, staleness state).
 
 **Priority:** Low — active game preservation covers the critical audio case.
+
+## Event priority/stagger system
+
+**What:** Add priority ranking to game events so that when 4+ fire simultaneously, lower-priority sounds are dropped or staggered.
+
+**Why:** When a big play happens (e.g., grand slam), multiple events fire at once (runScored + runner clears + count reset). Currently all sounds overlap freely, which could be cacophonous.
+
+**Pros:** Better audio UX during high-activity moments; cleaner soundscape.
+
+**Cons:** Adds complexity to the `_handleEvents` loop in engine.js; needs tuning to find the right priority order and max concurrent sounds.
+
+**Context:** The `_handleEvents` method in `src/audio/engine.js` is the natural place. Sort events by priority, cap at N, stagger with `Tone.now() + offset`. Suggested priority: runScored > inningChange > statusChange > outRecorded > runnerAdvance > strike > ball.
+
+**Depends on:** Tone.js audio engine PR.
+
+**Priority:** Medium — revisit once we can hear the overlapping sounds in practice.
+
+## Audio control UI
+
+**What:** Add a volume slider and mute toggle button to the Header component.
+
+**Why:** Users currently have no in-app way to adjust audio volume or mute — only browser-level controls. The `setMasterVolume()` and `pause()`/`resume()` APIs already exist.
+
+**Pros:** Complete audio UX; users can adjust without leaving the app.
+
+**Cons:** UI design decisions needed (placement, styling); adds state to Header.
+
+**Context:** `src/components/Header.js` is the natural home. Use MUI Slider + IconButton (VolumeUp/VolumeOff). Wire to `audio.setMasterVolume()` and `audio.pause()`/`audio.resume()` from `src/audio/index.js`.
+
+**Depends on:** Tone.js audio engine PR.
+
+**Priority:** Medium — nice-to-have before sharing with users.
+
+## Per-game live feed for active game (reduce ~10s latency to ~1-2s)
+
+**What:** Add a second polling tier that hits MLB's per-game live feed (`/api/v1.1/game/{gamePk}/feed/live`) for the active game, instead of relying solely on the batch schedule endpoint.
+
+**Why:** The current `/api/v1/schedule` endpoint updates ~10s behind MLB's gameday UI. It's a batch endpoint for all games and is deprioritized by MLB's infrastructure. The per-game live feed updates much faster — it's what powers MLB's own gameday page.
+
+**Pros:** Dramatically reduces latency for the active game's audio events. Sounds would feel nearly real-time instead of 10s behind the action.
+
+**Cons:** Adds a second API route, a second polling path, and a second normalization path (live feed response shape differs from schedule). More moving parts.
+
+**Context:** Two-tier approach — keep the schedule endpoint for the game list (slow poll, e.g., 10s), add per-game live feed for the active game only (fast poll, 500ms). New API route at `app/api/getGameLive/route.js` proxying `/api/v1.1/game/{gamePk}/feed/live`. The live feed response has `liveData.linescore` with all the fields `normalizeGame` needs (inning, balls, strikes, outs, runners, scores). Would need either a second normalizer or an adapter that reshapes the live feed response to match the schedule format before passing to `normalizeGame`. The `useGamePolling` hook would need to accept an optional `activeGameId` and switch to the live feed endpoint when one is set. The store's `ingestGames` could be extended with an `ingestGame(gameId, rawGame)` for single-game updates.
+
+**Depends on:** Tone.js audio engine PR.
+
+**Priority:** High — this is the biggest UX improvement available. The audio pipeline works, but 10s latency makes it feel disconnected from the action.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "mlb-musical-scoreboard",
       "version": "0.1.0",
       "dependencies": {
-        "@elemaudio/core": "^4.0.1",
-        "@elemaudio/web-renderer": "^4.0.3",
         "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
@@ -21,6 +19,7 @@
         "next": "^16.1.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "tone": "^15.1.22",
         "zustand": "^5.0.10"
       },
       "devDependencies": {
@@ -601,12 +600,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -778,30 +775,6 @@
       "peer": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@elemaudio/core": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@elemaudio/core/-/core-4.0.1.tgz",
-      "integrity": "sha512-O58CaR5ttxzPt1LwkJoXVipPLlZ8lZmOIHhJFiih3rWkfCZ3/H1X2XTG0HM2jAn3BokoP5jYSbnbEiQybyvRGw==",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "invariant": "^2.2.4",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "node_modules/@elemaudio/core/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
-    },
-    "node_modules/@elemaudio/web-renderer": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@elemaudio/web-renderer/-/web-renderer-4.0.3.tgz",
-      "integrity": "sha512-mvMt6SsUzcOEx97SGsf0u1/kafMkxWKtEa1FOuzwdzkmcdLAQIwouzZ87PExf452gi4tJqhMF0RDFb62LJqfZg==",
-      "dependencies": {
-        "@elemaudio/core": "^4.0.1",
-        "invariant": "^2.2.4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3067,6 +3040,19 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/automation-events": {
+      "version": "7.1.15",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.15.tgz",
+      "integrity": "sha512-NsHJlve3twcgs8IyP4iEYph7Fzpnh6klN7G5LahwvypakBjFbsiGHJxrqTmeHKREdu/Tx6oZboqNI0tD4MnFlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
@@ -4142,14 +4128,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -6037,11 +6015,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6145,11 +6118,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -6320,6 +6288,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/string-length": {
@@ -6654,6 +6633,16 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/tone": {
+      "version": "15.1.22",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
+      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.3.70",
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@elemaudio/core": "^4.0.1",
-    "@elemaudio/web-renderer": "^4.0.3",
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
@@ -16,6 +14,7 @@
     "next": "^16.1.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "tone": "^15.1.22",
     "zustand": "^5.0.10"
   },
   "devDependencies": {

--- a/src/audio/diffGameEvents.js
+++ b/src/audio/diffGameEvents.js
@@ -1,0 +1,83 @@
+/**
+ * Pure function: compares previous and next normalized game states,
+ * returns an array of game event descriptors for the audio engine.
+ *
+ * Branching:
+ * ├── prev=null, next=null → []
+ * ├── prev=null, next exists → [gameSelected] if Live
+ * ├── prev exists, next=null → []
+ * ├── prev === next → []
+ * └── diff fields → statusChange, runScored, inningChange,
+ *     outRecorded, strike, ball, runnerAdvance
+ */
+export function diffGameEvents(prev, next) {
+  const events = [];
+
+  // No game on either side
+  if (!prev && !next) return events;
+
+  // Game just selected
+  if (!prev && next) {
+    if (next.status === 'Live') {
+      events.push({ type: 'gameSelected', detail: {} });
+    }
+    return events;
+  }
+
+  // Game deselected
+  if (prev && !next) return events;
+
+  // Same reference = no change (leveraging store's referential stability)
+  if (prev === next) return events;
+
+  // Status transition
+  if (prev.status !== next.status) {
+    events.push({ type: 'statusChange', detail: { from: prev.status, to: next.status } });
+  }
+
+  // Score increases (ignore decreases — treat as data corrections)
+  if (next.homeScore > prev.homeScore) {
+    events.push({ type: 'runScored', detail: { team: 'home', runs: next.homeScore - prev.homeScore } });
+  }
+  if (next.awayScore > prev.awayScore) {
+    events.push({ type: 'runScored', detail: { team: 'away', runs: next.awayScore - prev.awayScore } });
+  }
+
+  // Inning change
+  if (next.inning !== prev.inning || next.isTopInning !== prev.isTopInning) {
+    events.push({ type: 'inningChange', detail: { inning: next.inning, isTop: next.isTopInning } });
+  }
+
+  // Guards for within-half-inning events
+  const sameHalfInning = prev.inning === next.inning && prev.isTopInning === next.isTopInning;
+
+  if (sameHalfInning) {
+    // Out recorded
+    if (next.outs > prev.outs) {
+      events.push({ type: 'outRecorded', detail: { outs: next.outs } });
+    }
+
+    // Strike
+    if (next.strikes > prev.strikes) {
+      events.push({ type: 'strike', detail: { count: next.strikes } });
+    }
+
+    // Ball
+    if (next.balls > prev.balls) {
+      events.push({ type: 'ball', detail: { count: next.balls } });
+    }
+  }
+
+  // Runner advances (defensive guard on runners array)
+  const prevRunners = prev.runners || [];
+  const runners = next.runners || [];
+  const len = Math.min(runners.length, 3);
+
+  for (let i = 0; i < len; i++) {
+    if (!prevRunners[i] && runners[i]) {
+      events.push({ type: 'runnerAdvance', detail: { base: i + 1 } });
+    }
+  }
+
+  return events;
+}

--- a/src/audio/diffGameEvents.test.js
+++ b/src/audio/diffGameEvents.test.js
@@ -1,0 +1,212 @@
+import { diffGameEvents } from './diffGameEvents';
+
+/** Helper: create a minimal normalized game object */
+function makeGame(overrides = {}) {
+  return {
+    gameId: '1',
+    status: 'Live',
+    homeScore: 0,
+    awayScore: 0,
+    inning: 1,
+    isTopInning: true,
+    inningState: 'Middle',
+    balls: 0,
+    strikes: 0,
+    outs: 0,
+    runners: [false, false, false],
+    homeTeam: { id: 1, name: 'Home', abbreviation: 'HOM' },
+    awayTeam: { id: 2, name: 'Away', abbreviation: 'AWY' },
+    gameDate: '2025-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('diffGameEvents', () => {
+  // --- Null/identity cases ---
+
+  test('returns [] when both prev and next are null', () => {
+    expect(diffGameEvents(null, null)).toEqual([]);
+  });
+
+  test('returns [] when prev === next (same reference)', () => {
+    const game = makeGame();
+    expect(diffGameEvents(game, game)).toEqual([]);
+  });
+
+  test('returns [] when game is deselected (prev exists, next null)', () => {
+    expect(diffGameEvents(makeGame(), null)).toEqual([]);
+  });
+
+  // --- Game selected ---
+
+  test('returns gameSelected when selecting a Live game', () => {
+    const events = diffGameEvents(null, makeGame({ status: 'Live' }));
+    expect(events).toEqual([{ type: 'gameSelected', detail: {} }]);
+  });
+
+  test('returns [] when selecting a non-Live game', () => {
+    expect(diffGameEvents(null, makeGame({ status: 'Preview' }))).toEqual([]);
+    expect(diffGameEvents(null, makeGame({ status: 'Final' }))).toEqual([]);
+  });
+
+  // --- Status changes ---
+
+  test('detects status change', () => {
+    const prev = makeGame({ status: 'Preview' });
+    const next = makeGame({ status: 'Live' });
+    const events = diffGameEvents(prev, next);
+    expect(events).toContainEqual({
+      type: 'statusChange',
+      detail: { from: 'Preview', to: 'Live' },
+    });
+  });
+
+  // --- Score changes ---
+
+  test('detects home run scored', () => {
+    const prev = makeGame({ homeScore: 2 });
+    const next = makeGame({ homeScore: 3 });
+    const events = diffGameEvents(prev, next);
+    expect(events).toContainEqual({
+      type: 'runScored',
+      detail: { team: 'home', runs: 1 },
+    });
+  });
+
+  test('detects away run scored with multiple runs', () => {
+    const prev = makeGame({ awayScore: 0 });
+    const next = makeGame({ awayScore: 3 });
+    const events = diffGameEvents(prev, next);
+    expect(events).toContainEqual({
+      type: 'runScored',
+      detail: { team: 'away', runs: 3 },
+    });
+  });
+
+  test('ignores score decrease (data correction)', () => {
+    const prev = makeGame({ homeScore: 5 });
+    const next = makeGame({ homeScore: 4 });
+    const events = diffGameEvents(prev, next);
+    const scoreEvents = events.filter((e) => e.type === 'runScored');
+    expect(scoreEvents).toEqual([]);
+  });
+
+  // --- Inning changes ---
+
+  test('detects inning number change', () => {
+    const prev = makeGame({ inning: 3, isTopInning: false });
+    const next = makeGame({ inning: 4, isTopInning: true });
+    const events = diffGameEvents(prev, next);
+    expect(events).toContainEqual({
+      type: 'inningChange',
+      detail: { inning: 4, isTop: true },
+    });
+  });
+
+  test('detects half-inning flip', () => {
+    const prev = makeGame({ inning: 5, isTopInning: true });
+    const next = makeGame({ inning: 5, isTopInning: false });
+    const events = diffGameEvents(prev, next);
+    expect(events).toContainEqual({
+      type: 'inningChange',
+      detail: { inning: 5, isTop: false },
+    });
+  });
+
+  // --- Outs ---
+
+  test('detects out recorded within same half-inning', () => {
+    const prev = makeGame({ outs: 1 });
+    const next = makeGame({ outs: 2 });
+    const events = diffGameEvents(prev, next);
+    expect(events).toContainEqual({
+      type: 'outRecorded',
+      detail: { outs: 2 },
+    });
+  });
+
+  test('does not fire outRecorded on inning change (outs reset)', () => {
+    const prev = makeGame({ inning: 3, isTopInning: true, outs: 2 });
+    const next = makeGame({ inning: 3, isTopInning: false, outs: 0 });
+    const events = diffGameEvents(prev, next);
+    const outEvents = events.filter((e) => e.type === 'outRecorded');
+    expect(outEvents).toEqual([]);
+  });
+
+  // --- Strikes and balls ---
+
+  test('detects strike within same half-inning', () => {
+    const prev = makeGame({ strikes: 0 });
+    const next = makeGame({ strikes: 1 });
+    const events = diffGameEvents(prev, next);
+    expect(events).toContainEqual({
+      type: 'strike',
+      detail: { count: 1 },
+    });
+  });
+
+  test('detects ball within same half-inning', () => {
+    const prev = makeGame({ balls: 1 });
+    const next = makeGame({ balls: 2 });
+    const events = diffGameEvents(prev, next);
+    expect(events).toContainEqual({
+      type: 'ball',
+      detail: { count: 2 },
+    });
+  });
+
+  test('does not fire strike/ball on inning change', () => {
+    const prev = makeGame({ inning: 1, isTopInning: true, strikes: 2, balls: 3 });
+    const next = makeGame({ inning: 1, isTopInning: false, strikes: 0, balls: 0 });
+    const events = diffGameEvents(prev, next);
+    const countEvents = events.filter((e) => e.type === 'strike' || e.type === 'ball');
+    expect(countEvents).toEqual([]);
+  });
+
+  // --- Runners ---
+
+  test('detects runner advance to each base', () => {
+    const prev = makeGame({ runners: [false, false, false] });
+    const next = makeGame({ runners: [true, true, true] });
+    const events = diffGameEvents(prev, next);
+    expect(events).toContainEqual({ type: 'runnerAdvance', detail: { base: 1 } });
+    expect(events).toContainEqual({ type: 'runnerAdvance', detail: { base: 2 } });
+    expect(events).toContainEqual({ type: 'runnerAdvance', detail: { base: 3 } });
+  });
+
+  test('does not fire runnerAdvance when runner leaves base', () => {
+    const prev = makeGame({ runners: [true, true, false] });
+    const next = makeGame({ runners: [false, false, true] });
+    const events = diffGameEvents(prev, next);
+    const runnerEvents = events.filter((e) => e.type === 'runnerAdvance');
+    // Only base 3 is a new runner
+    expect(runnerEvents).toEqual([{ type: 'runnerAdvance', detail: { base: 3 } }]);
+  });
+
+  // --- Edge cases ---
+
+  test('handles malformed runners (undefined)', () => {
+    const prev = makeGame({ runners: undefined });
+    const next = makeGame({ runners: [true, false, false] });
+    const events = diffGameEvents(prev, next);
+    expect(events).toContainEqual({ type: 'runnerAdvance', detail: { base: 1 } });
+  });
+
+  test('handles malformed runners (empty array)', () => {
+    const prev = makeGame({ runners: [] });
+    const next = makeGame({ runners: [false, true, false] });
+    const events = diffGameEvents(prev, next);
+    // prev[1] is undefined (falsy), next[1] is true → runner advance
+    expect(events).toContainEqual({ type: 'runnerAdvance', detail: { base: 2 } });
+  });
+
+  test('produces multiple events in a single diff', () => {
+    const prev = makeGame({ homeScore: 1, runners: [false, true, false], outs: 0 });
+    const next = makeGame({ homeScore: 2, runners: [true, false, false], outs: 1 });
+    const events = diffGameEvents(prev, next);
+    const types = events.map((e) => e.type);
+    expect(types).toContain('runScored');
+    expect(types).toContain('outRecorded');
+    expect(types).toContain('runnerAdvance'); // base 1 new
+  });
+});

--- a/src/audio/engine.js
+++ b/src/audio/engine.js
@@ -1,5 +1,6 @@
-import WebRenderer from '@elemaudio/web-renderer';
-import { el } from '@elemaudio/core';
+import * as Tone from 'tone';
+import { diffGameEvents } from './diffGameEvents';
+import { SoundBank } from './sounds';
 
 let instance = null;
 
@@ -8,55 +9,70 @@ export class AudioEngine {
     if (instance) return instance;
     instance = this;
 
-    this.ctx = null;
-    this.core = null;
-    this.ready = false;
+    this.masterGain = null;
+    this.soundBank = null;
     this.unsub = null;
-    this.volume = 1;
-    this.playing = false;
+    this.connected = false;
+    this.prevGame = null;
+    this._volume = 1;
+    this._paused = false;
   }
 
   async connect(store) {
-    if (this.ctx) return;
+    if (this.connected) return;
 
-    this.ctx = new AudioContext();
-    this.core = new WebRenderer();
+    try {
+      await Tone.start();
 
-    const node = await this.core.initialize(this.ctx, {
-      numberOfInputs: 0,
-      numberOfOutputs: 1,
-      outputChannelCount: [2],
-    });
+      this.masterGain = new Tone.Gain(this._volume).toDestination();
+      this.soundBank = new SoundBank(this.masterGain);
+      this.connected = true;
 
-    node.connect(this.ctx.destination);
-    this.ready = true;
+      // Snapshot initial active game
+      const state = store.getState();
+      this.prevGame = state.activeGameId
+        ? state.games[state.activeGameId] ?? null
+        : null;
 
-    // Subscribe to store — re-render when activeGameId changes
-    let prevActiveGameId = store.getState().activeGameId;
-    this._render(prevActiveGameId);
+      // Subscribe to store — diff active game object on every change
+      this.unsub = store.subscribe((state) => {
+        const nextGame = state.activeGameId
+          ? state.games[state.activeGameId] ?? null
+          : null;
 
-    this.unsub = store.subscribe((state) => {
-      if (state.activeGameId !== prevActiveGameId) {
-        prevActiveGameId = state.activeGameId;
-        this._render(state.activeGameId);
-      }
-    });
+        if (nextGame !== this.prevGame) {
+          const events = diffGameEvents(this.prevGame, nextGame);
+          this._handleEvents(events);
+          this.prevGame = nextGame;
+        }
+      });
+    } catch (err) {
+      // Cleanup AudioContext if Tone.start() succeeded but something else failed
+      try {
+        Tone.getContext().rawContext.close();
+      } catch (_) { /* already closed or never opened */ }
+      this.connected = false;
+      this.masterGain = null;
+      this.soundBank = null;
+      instance = null;
+      throw err;
+    }
   }
 
-  _render(activeGameId) {
-    if (!this.ready) return;
+  _handleEvents(events) {
+    if (this._paused) return;
 
-    if (activeGameId && this.ctx.state === 'running') {
-      const tone = el.mul(
-        el.const({ key: 'vol', value: this.volume }),
-        el.cycle({ key: 'sine', frequency: 440 }),
-      );
-      this.core.render(tone, tone);
-      this.playing = true;
-    } else {
-      const silence = el.const({ key: 'silence', value: 0 });
-      this.core.render(silence, silence);
-      this.playing = false;
+    for (const event of events) {
+      switch (event.type) {
+        case 'runScored': this.soundBank.playRunScored(event.detail); break;
+        case 'outRecorded': this.soundBank.playOutRecorded(event.detail); break;
+        case 'inningChange': this.soundBank.playInningChange(event.detail); break;
+        case 'runnerAdvance': this.soundBank.playRunnerAdvance(event.detail); break;
+        case 'statusChange': this.soundBank.playStatusChange(event.detail); break;
+        case 'strike': this.soundBank.playStrike(event.detail); break;
+        case 'ball': this.soundBank.playBall(event.detail); break;
+        // gameSelected is intentionally silent — no sound on initial selection
+      }
     }
   }
 
@@ -65,36 +81,38 @@ export class AudioEngine {
       this.unsub();
       this.unsub = null;
     }
-    if (this.ctx) {
-      this.ctx.close();
-      this.ctx = null;
-    }
-    this.core = null;
-    this.ready = false;
-    this.playing = false;
+    this.soundBank?.dispose();
+    this.soundBank = null;
+    this.masterGain?.dispose();
+    this.masterGain = null;
+    this.connected = false;
+    this.prevGame = null;
+    this._paused = false;
     instance = null;
   }
 
   pause() {
-    if (this.ctx) this.ctx.suspend();
+    if (this.masterGain && !this._paused) {
+      this._paused = true;
+      this.masterGain.gain.value = 0;
+    }
   }
 
   resume() {
-    if (this.ctx) this.ctx.resume();
+    if (this.masterGain && this._paused) {
+      this._paused = false;
+      this.masterGain.gain.value = this._volume;
+    }
   }
 
   setMasterVolume(v) {
-    this.volume = Math.max(0, Math.min(1, v));
-    if (this.ready && this.playing) {
-      const tone = el.mul(
-        el.const({ key: 'vol', value: this.volume }),
-        el.cycle({ key: 'sine', frequency: 440 }),
-      );
-      this.core.render(tone, tone);
+    this._volume = Math.max(0, Math.min(1, v));
+    if (this.masterGain && !this._paused) {
+      this.masterGain.gain.value = this._volume;
     }
   }
 
   isConnected() {
-    return this.ready && this.ctx?.state === 'running';
+    return this.connected;
   }
 }

--- a/src/audio/engine.test.js
+++ b/src/audio/engine.test.js
@@ -1,0 +1,198 @@
+import { AudioEngine } from './engine';
+
+// Mock Tone.js
+jest.mock('tone', () => ({
+  start: jest.fn().mockResolvedValue(undefined),
+  Gain: jest.fn().mockImplementation(() => ({
+    toDestination: jest.fn().mockReturnThis(),
+    gain: { value: 1 },
+    dispose: jest.fn(),
+  })),
+  getContext: jest.fn(() => ({
+    rawContext: { close: jest.fn() },
+  })),
+  now: jest.fn(() => 0),
+}));
+
+// Mock SoundBank
+jest.mock('./sounds', () => ({
+  SoundBank: jest.fn().mockImplementation(() => ({
+    playRunScored: jest.fn(),
+    playOutRecorded: jest.fn(),
+    playInningChange: jest.fn(),
+    playRunnerAdvance: jest.fn(),
+    playStatusChange: jest.fn(),
+    playStrike: jest.fn(),
+    playBall: jest.fn(),
+    dispose: jest.fn(),
+  })),
+}));
+
+const Tone = require('tone');
+const { SoundBank } = require('./sounds');
+
+/** Create a minimal Zustand-like store */
+function createMockStore(initialState) {
+  let state = initialState;
+  const listeners = new Set();
+  return {
+    getState: () => state,
+    subscribe: (fn) => {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    },
+    setState: (partial) => {
+      state = { ...state, ...partial };
+      listeners.forEach((fn) => fn(state));
+    },
+  };
+}
+
+function makeGame(overrides = {}) {
+  return {
+    gameId: '1', status: 'Live', homeScore: 0, awayScore: 0,
+    inning: 1, isTopInning: true, balls: 0, strikes: 0, outs: 0,
+    runners: [false, false, false], ...overrides,
+  };
+}
+
+describe('AudioEngine', () => {
+  let engine;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset singleton
+    engine = new AudioEngine();
+    engine.disconnect();
+    engine = new AudioEngine();
+  });
+
+  afterEach(() => {
+    engine.disconnect();
+  });
+
+  // --- Connect lifecycle ---
+
+  test('connect initializes Tone.js and subscribes to store', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    expect(Tone.start).toHaveBeenCalled();
+    expect(Tone.Gain).toHaveBeenCalled();
+    expect(SoundBank).toHaveBeenCalled();
+    expect(engine.isConnected()).toBe(true);
+  });
+
+  test('connect is idempotent', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+    await engine.connect(store);
+
+    expect(Tone.start).toHaveBeenCalledTimes(1);
+  });
+
+  test('connect cleans up AudioContext on failure', async () => {
+    const mockClose = jest.fn();
+    Tone.getContext.mockReturnValue({ rawContext: { close: mockClose } });
+    SoundBank.mockImplementationOnce(() => { throw new Error('SoundBank failed'); });
+
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await expect(engine.connect(store)).rejects.toThrow('SoundBank failed');
+
+    expect(mockClose).toHaveBeenCalled();
+    expect(engine.isConnected()).toBe(false);
+  });
+
+  // --- Disconnect ---
+
+  test('disconnect cleans up everything', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    const soundBank = engine.soundBank;
+    const masterGain = engine.masterGain;
+
+    engine.disconnect();
+
+    expect(soundBank.dispose).toHaveBeenCalled();
+    expect(masterGain.dispose).toHaveBeenCalled();
+    expect(engine.isConnected()).toBe(false);
+  });
+
+  // --- Store subscription and event dispatch ---
+
+  test('dispatches events when active game state changes', async () => {
+    const game1 = makeGame({ homeScore: 0 });
+    const game2 = makeGame({ homeScore: 1 });
+
+    const store = createMockStore({ activeGameId: '1', games: { '1': game1 } });
+    await engine.connect(store);
+
+    // Update game with score change
+    store.setState({ games: { '1': game2 } });
+
+    expect(engine.soundBank.playRunScored).toHaveBeenCalledWith({ team: 'home', runs: 1 });
+  });
+
+  test('does not dispatch when game reference is unchanged', async () => {
+    const game = makeGame();
+    const store = createMockStore({ activeGameId: '1', games: { '1': game } });
+    await engine.connect(store);
+
+    // Trigger subscription with same game reference
+    store.setState({ activeGameId: '1', games: { '1': game } });
+
+    expect(engine.soundBank.playRunScored).not.toHaveBeenCalled();
+    expect(engine.soundBank.playOutRecorded).not.toHaveBeenCalled();
+  });
+
+  // --- Pause / Resume ---
+
+  test('pause sets masterGain to 0', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    engine.pause();
+    expect(engine.masterGain.gain.value).toBe(0);
+  });
+
+  test('resume restores volume', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+    engine.setMasterVolume(0.7);
+
+    engine.pause();
+    expect(engine.masterGain.gain.value).toBe(0);
+
+    engine.resume();
+    expect(engine.masterGain.gain.value).toBe(0.7);
+  });
+
+  test('events are not dispatched while paused', async () => {
+    const game1 = makeGame({ outs: 0 });
+    const game2 = makeGame({ outs: 1 });
+
+    const store = createMockStore({ activeGameId: '1', games: { '1': game1 } });
+    await engine.connect(store);
+    engine.pause();
+
+    store.setState({ games: { '1': game2 } });
+    expect(engine.soundBank.playOutRecorded).not.toHaveBeenCalled();
+  });
+
+  // --- Volume ---
+
+  test('setMasterVolume clamps to 0-1', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    engine.setMasterVolume(1.5);
+    expect(engine.masterGain.gain.value).toBe(1);
+
+    engine.setMasterVolume(-0.5);
+    expect(engine.masterGain.gain.value).toBe(0);
+
+    engine.setMasterVolume(0.5);
+    expect(engine.masterGain.gain.value).toBe(0.5);
+  });
+});

--- a/src/audio/sounds.js
+++ b/src/audio/sounds.js
@@ -1,0 +1,106 @@
+import * as Tone from 'tone';
+
+/**
+ * SoundBank: manages Tone.js synths and provides one method per game event type.
+ * Synths are lazily created on first use to avoid unnecessary AudioContext allocation.
+ * All synths route through the provided master Gain node.
+ *
+ * Uses PolySynth for the main synth to handle overlapping notes from
+ * multiple events firing in the same dispatch cycle.
+ */
+export class SoundBank {
+  constructor(masterGain) {
+    this.master = masterGain;
+    this._synth = null;
+    this._membrane = null;
+  }
+
+  // Lazy synth accessors
+  get synth() {
+    if (!this._synth) {
+      this._synth = new Tone.PolySynth(Tone.Synth, {
+        maxPolyphony: 6,
+        voice: Tone.Synth,
+        options: {
+          oscillator: { type: 'triangle' },
+          envelope: { attack: 0.01, decay: 0.2, sustain: 0.1, release: 0.3 },
+        },
+      }).connect(this.master);
+    }
+    return this._synth;
+  }
+
+  get membrane() {
+    if (!this._membrane) {
+      this._membrane = new Tone.MembraneSynth({
+        pitchDecay: 0.05,
+        octaves: 4,
+        envelope: { attack: 0.001, decay: 0.2, sustain: 0, release: 0.2 },
+      }).connect(this.master);
+    }
+    return this._membrane;
+  }
+
+  /** Rising arpeggio — pitch count varies by runs scored */
+  playRunScored(detail) {
+    const now = Tone.now();
+    const notes = ['C5', 'E5', 'G5', 'C6'];
+    const count = Math.min(detail.runs || 1, notes.length);
+    for (let i = 0; i < count; i++) {
+      this.synth.triggerAttackRelease(notes[i], '16n', now + i * 0.1);
+    }
+  }
+
+  /** Short percussive hit */
+  playOutRecorded() {
+    this.membrane.triggerAttackRelease('C2', '8n');
+  }
+
+  /** Two-tone chime: ascending for top of inning, descending for bottom */
+  playInningChange(detail) {
+    const now = Tone.now();
+    if (detail.isTop) {
+      this.synth.triggerAttackRelease('E4', '16n', now);
+      this.synth.triggerAttackRelease('A4', '16n', now + 0.15);
+    } else {
+      this.synth.triggerAttackRelease('A4', '16n', now);
+      this.synth.triggerAttackRelease('E4', '16n', now + 0.15);
+    }
+  }
+
+  /** Blip pitched by base position: 1st=low, 2nd=mid, 3rd=high */
+  playRunnerAdvance(detail) {
+    const pitchMap = { 1: 'G3', 2: 'D4', 3: 'A4' };
+    const note = pitchMap[detail.base] || 'G3';
+    this.synth.triggerAttackRelease(note, '32n');
+  }
+
+  /** Status change: warm swell for Live, descending resolution for Final */
+  playStatusChange(detail) {
+    const now = Tone.now();
+    if (detail.to === 'Live') {
+      this.synth.triggerAttackRelease('C4', '2n', now);
+    } else if (detail.to === 'Final') {
+      this.synth.triggerAttackRelease('E4', '8n', now);
+      this.synth.triggerAttackRelease('C4', '8n', now + 0.2);
+      this.synth.triggerAttackRelease('A3', '4n', now + 0.4);
+    }
+  }
+
+  /** Short high tick */
+  playStrike() {
+    this.synth.triggerAttackRelease('E5', '32n');
+  }
+
+  /** Short low tick */
+  playBall() {
+    this.synth.triggerAttackRelease('G3', '32n');
+  }
+
+  dispose() {
+    this._synth?.dispose();
+    this._membrane?.dispose();
+    this._synth = null;
+    this._membrane = null;
+  }
+}

--- a/src/audio/sounds.test.js
+++ b/src/audio/sounds.test.js
@@ -1,0 +1,137 @@
+import { SoundBank } from './sounds';
+
+// Mock Tone.js
+jest.mock('tone', () => {
+  const mockSynth = () => ({
+    triggerAttackRelease: jest.fn(),
+    connect: jest.fn().mockReturnThis(),
+    dispose: jest.fn(),
+  });
+
+  return {
+    Synth: jest.fn(),
+    PolySynth: jest.fn().mockImplementation(() => mockSynth()),
+    MembraneSynth: jest.fn().mockImplementation(() => mockSynth()),
+    now: jest.fn(() => 0),
+  };
+});
+
+const Tone = require('tone');
+
+function createMasterGain() {
+  return { gain: { value: 1 } };
+}
+
+describe('SoundBank', () => {
+  let bank;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    bank = new SoundBank(createMasterGain());
+  });
+
+  afterEach(() => {
+    bank.dispose();
+  });
+
+  // --- Lazy creation ---
+
+  test('does not create synths on construction', () => {
+    expect(Tone.PolySynth).not.toHaveBeenCalled();
+    expect(Tone.MembraneSynth).not.toHaveBeenCalled();
+  });
+
+  test('creates PolySynth lazily on first synth access', () => {
+    bank.playStrike();
+    expect(Tone.PolySynth).toHaveBeenCalledTimes(1);
+  });
+
+  test('reuses PolySynth on subsequent calls', () => {
+    bank.playStrike();
+    bank.playBall();
+    expect(Tone.PolySynth).toHaveBeenCalledTimes(1);
+  });
+
+  test('creates MembraneSynth lazily on first membrane access', () => {
+    bank.playOutRecorded();
+    expect(Tone.MembraneSynth).toHaveBeenCalledTimes(1);
+  });
+
+  // --- Trigger calls ---
+
+  test('playRunScored triggers synth with arpeggio', () => {
+    bank.playRunScored({ runs: 2 });
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledTimes(2);
+  });
+
+  test('playRunScored caps at 4 notes', () => {
+    bank.playRunScored({ runs: 10 });
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledTimes(4);
+  });
+
+  test('playOutRecorded triggers membrane', () => {
+    bank.playOutRecorded();
+    expect(bank.membrane.triggerAttackRelease).toHaveBeenCalledWith('C2', '8n');
+  });
+
+  test('playInningChange triggers two notes for top of inning', () => {
+    bank.playInningChange({ isTop: true });
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledTimes(2);
+  });
+
+  test('playInningChange triggers two notes for bottom of inning', () => {
+    bank.playInningChange({ isTop: false });
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledTimes(2);
+  });
+
+  test('playRunnerAdvance triggers at pitch mapped to base', () => {
+    bank.playRunnerAdvance({ base: 1 });
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledWith('G3', '32n');
+
+    bank.playRunnerAdvance({ base: 2 });
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledWith('D4', '32n');
+
+    bank.playRunnerAdvance({ base: 3 });
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledWith('A4', '32n');
+  });
+
+  test('playStatusChange plays swell for Live', () => {
+    bank.playStatusChange({ to: 'Live' });
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledTimes(1);
+  });
+
+  test('playStatusChange plays resolution for Final', () => {
+    bank.playStatusChange({ to: 'Final' });
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledTimes(3);
+  });
+
+  test('playStrike triggers high tick', () => {
+    bank.playStrike();
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledWith('E5', '32n');
+  });
+
+  test('playBall triggers low tick', () => {
+    bank.playBall();
+    expect(bank.synth.triggerAttackRelease).toHaveBeenCalledWith('G3', '32n');
+  });
+
+  // --- Dispose ---
+
+  test('dispose cleans up all synths', () => {
+    // Force creation
+    bank.playStrike();
+    bank.playOutRecorded();
+    const synth = bank._synth;
+    const membrane = bank._membrane;
+
+    bank.dispose();
+    expect(synth.dispose).toHaveBeenCalled();
+    expect(membrane.dispose).toHaveBeenCalled();
+    expect(bank._synth).toBeNull();
+    expect(bank._membrane).toBeNull();
+  });
+
+  test('dispose is safe when no synths were created', () => {
+    expect(() => bank.dispose()).not.toThrow();
+  });
+});

--- a/src/components/MainLayout.js
+++ b/src/components/MainLayout.js
@@ -7,6 +7,7 @@ import GameList from './GameList';
 
 import { useGameStore } from '../store/gameStore';
 import { useGamePolling } from '../hooks/useGamePolling';
+import * as audio from '../audio';
 
 const MainLayout = ({ gameId }) => {
   const router = useRouter();
@@ -15,7 +16,15 @@ const MainLayout = ({ gameId }) => {
   const activeGameId = useGameStore((s) => s.activeGameId);
   const setActiveGame = useGameStore((s) => s.setActiveGame);
 
-  useGamePolling({ interval: 5000 });
+  useGamePolling({ interval: 1000 });
+
+  // Audio engine is a page-level singleton — survives component remounts (HMR, Strict Mode).
+  // Cleanup happens on page unload, not component unmount.
+  useEffect(() => {
+    const cleanup = () => audio.disconnect();
+    window.addEventListener('beforeunload', cleanup);
+    return () => window.removeEventListener('beforeunload', cleanup);
+  }, []);
 
   // Sync URL gameId with store
   useEffect(() => {
@@ -24,8 +33,13 @@ const MainLayout = ({ gameId }) => {
 
   const gamesLoading = Object.keys(games).length === 0;
 
-  const handleGameSelect = useCallback((id) => {
+  const handleGameSelect = useCallback(async (id) => {
     if (games[id]?.status !== 'Live') return;
+
+    // Connect audio on first interaction (user gesture satisfies AudioContext requirement)
+    if (!audio.isConnected()) {
+      await audio.connect(useGameStore);
+    }
 
     if (activeGameId === String(id)) {
       setActiveGame(null);


### PR DESCRIPTION
## Summary
- Replace Elementary Audio with Tone.js for event-driven sound on game state changes
- Add `diffGameEvents` pure function: diffs prev/next game state → event descriptors
- Add `SoundBank` class: PolySynth (6-voice) + MembraneSynth with lazy creation
- Rewrite `AudioEngine`: store subscription → diffGameEvents → SoundBank pipeline
- Wire audio into MainLayout on first game click (AudioContext user gesture)
- Reduce poll interval from 5s to 1s for responsiveness
- Sound mapping: arpeggio (runs), percussive hit (outs), chime (inning), blip (runners), tick (strikes/balls), swell/resolution (status)
- 108 tests passing (3 new test files for audio layer)

## Pre-Landing Review
Pre-Landing Review: 2 issues (0 critical, 2 informational)

**Issues** (non-blocking, fixed before commit):
- Debug `console.log` and `window.__audioTest` helper removed from engine.js

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] All Jest tests pass (108 tests, 7 suites)
- [x] Production build succeeds
- [x] Manual QA: sounds play via `__audioTest` helpers in dev
- [x] Audio connects on game click, disconnects on page unload

🤖 Generated with [Claude Code](https://claude.com/claude-code)