### PR TITLE
feat: linger fast polling after game deselection

### DIFF
--- a/src/hooks/useLiveGamePolling.js
+++ b/src/hooks/useLiveGamePolling.js
@@ -1,11 +1,14 @@
+import { useEffect, useRef } from 'react';
 import { fetchGameLive } from '../services/api';
 import { useGameStore } from '../store/gameStore';
 import { adaptLiveFeed } from '../utils/adaptLiveFeed';
 import { usePollingLoop } from './usePollingLoop';
 
-export function useLiveGamePolling(activeGameId, { interval = 1000 } = {}) {
+export function useLiveGamePolling(activeGameId, { interval = 1000, lingerPolls = 2 } = {}) {
   const ingestGame = useGameStore((s) => s.ingestGame);
+  const prevGameIdRef = useRef(null);
 
+  // Main polling — unchanged behavior
   usePollingLoop(() => {
     const seq = Date.now();
     return fetchGameLive(activeGameId).then((raw) => {
@@ -13,6 +16,41 @@ export function useLiveGamePolling(activeGameId, { interval = 1000 } = {}) {
       if (adapted) ingestGame(adapted, seq);
     });
   }, { interval, enabled: !!activeGameId });
+
+  // Linger polling — fire N more polls for the previous game after deselection
+  useEffect(() => {
+    const prevId = prevGameIdRef.current;
+    prevGameIdRef.current = activeGameId;
+
+    // Only linger if we had a previous game and it changed
+    if (!prevId || prevId === activeGameId) return;
+
+    let remaining = lingerPolls;
+    let mounted = true;
+    let timer;
+
+    async function tick() {
+      if (!mounted || remaining <= 0) return;
+      remaining--;
+      try {
+        const raw = await fetchGameLive(prevId);
+        const adapted = adaptLiveFeed(raw);
+        if (adapted) ingestGame(adapted, undefined); // no seq — avoid lastAcceptedLiveSeq interference
+      } catch (err) {
+        console.error('[useLiveGamePolling] linger poll error:', err);
+      }
+      if (mounted && remaining > 0) {
+        timer = setTimeout(tick, interval);
+      }
+    }
+
+    timer = setTimeout(tick, interval); // first linger poll after one interval
+
+    return () => {
+      mounted = false;
+      clearTimeout(timer);
+    };
+  }, [activeGameId, interval, lingerPolls, ingestGame]);
 }
 
 export default useLiveGamePolling;

--- a/src/hooks/useLiveGamePolling.test.js
+++ b/src/hooks/useLiveGamePolling.test.js
@@ -72,22 +72,103 @@ describe('useLiveGamePolling', () => {
     expect(fetchGameLive).not.toHaveBeenCalled();
   });
 
-  it('stops polling when activeGameId changes to null', async () => {
+  it('linger-polls prev game after deselection then stops', async () => {
     fetchGameLive.mockResolvedValue(makeLiveFeedResponse(718405));
 
     const { rerender } = renderHook(
-      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000 }),
+      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000, lingerPolls: 2 }),
       { initialProps: { gameId: '718405' } },
     );
 
+    // Initial active poll
     await act(async () => {});
     expect(fetchGameLive).toHaveBeenCalledTimes(1);
 
+    // Deselect — linger starts
     rerender({ gameId: null });
+
+    // First linger poll after 1 interval
+    await act(async () => { jest.advanceTimersByTime(1000); });
+    await act(async () => {});
+    expect(fetchGameLive).toHaveBeenCalledTimes(2);
+    expect(fetchGameLive).toHaveBeenLastCalledWith('718405');
+
+    // Second linger poll after another interval
+    await act(async () => { jest.advanceTimersByTime(1000); });
+    await act(async () => {});
+    expect(fetchGameLive).toHaveBeenCalledTimes(3);
+
+    // No more polls after linger exhausted
+    await act(async () => { jest.advanceTimersByTime(5000); });
+    await act(async () => {});
+    expect(fetchGameLive).toHaveBeenCalledTimes(3);
+  });
+
+  it('linger-polls prev game when switching A→B', async () => {
+    fetchGameLive.mockImplementation((id) =>
+      Promise.resolve(makeLiveFeedResponse(Number(id))),
+    );
+
+    const { rerender } = renderHook(
+      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000, lingerPolls: 2 }),
+      { initialProps: { gameId: '111' } },
+    );
+
+    // Initial active poll for game 111
+    await act(async () => {});
+    expect(fetchGameLive).toHaveBeenCalledTimes(1);
+    expect(fetchGameLive).toHaveBeenCalledWith('111');
+
+    // Switch to game 222 — active polls 222, linger polls 111
+    rerender({ gameId: '222' });
+    await act(async () => {}); // immediate active poll for 222
+
+    // After 1 interval: second active poll for 222 + first linger poll for 111
+    await act(async () => { jest.advanceTimersByTime(1000); });
+    await act(async () => {});
+
+    // After another interval: third active poll for 222 + second linger poll for 111
+    await act(async () => { jest.advanceTimersByTime(1000); });
+    await act(async () => {});
+
+    const calls = fetchGameLive.mock.calls.map(([id]) => id);
+    expect(calls.filter((id) => id === '222').length).toBeGreaterThanOrEqual(2);
+    expect(calls.filter((id) => id === '111').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('cancels linger when a new game is selected mid-linger', async () => {
+    fetchGameLive.mockImplementation((id) =>
+      Promise.resolve(makeLiveFeedResponse(Number(id))),
+    );
+
+    const { rerender } = renderHook(
+      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000, lingerPolls: 2 }),
+      { initialProps: { gameId: '111' } },
+    );
+
+    await act(async () => {}); // initial poll
+
+    // Deselect — linger starts for 111
+    rerender({ gameId: null });
+
+    // First linger poll fires
+    await act(async () => { jest.advanceTimersByTime(1000); });
+    await act(async () => {});
+
+    const callsBeforeReselect = fetchGameLive.mock.calls.length;
+
+    // Select game 222 — should cancel linger for 111, start linger for null (no-op since prev=null after cleanup)
+    rerender({ gameId: '222' });
+    await act(async () => {}); // immediate active poll for 222
+
+    // Advance several intervals — should only see 222 polls, no more 111 linger polls
     await act(async () => { jest.advanceTimersByTime(5000); });
     await act(async () => {});
 
-    expect(fetchGameLive).toHaveBeenCalledTimes(1);
+    const callsAfterReselect = fetchGameLive.mock.calls.slice(callsBeforeReselect);
+    const lingerCallsFor111 = callsAfterReselect.filter(([id]) => id === '111');
+    // At most 1 more linger poll for 111 (the one already scheduled), but the cleanup should prevent the second
+    expect(lingerCallsFor111.length).toBeLessThanOrEqual(1);
   });
 
   it('sets pollError on fetch failure', async () => {
@@ -120,6 +201,28 @@ describe('useLiveGamePolling', () => {
     const { lastAcceptedLiveSeq, lastAcceptedSeq } = useGameStore.getState();
     expect(lastAcceptedLiveSeq).toBeGreaterThan(0);
     expect(lastAcceptedSeq).toBe(0); // schedule tier untouched
+  });
+
+  it('linger polls do not update lastAcceptedLiveSeq', async () => {
+    fetchGameLive.mockResolvedValue(makeLiveFeedResponse(718405));
+
+    const { rerender } = renderHook(
+      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000, lingerPolls: 2 }),
+      { initialProps: { gameId: '718405' } },
+    );
+
+    await act(async () => {});
+    const { lastAcceptedLiveSeq: seqAfterActive } = useGameStore.getState();
+
+    // Deselect — linger starts
+    rerender({ gameId: null });
+
+    // First linger poll
+    await act(async () => { jest.advanceTimersByTime(1000); });
+    await act(async () => {});
+
+    const { lastAcceptedLiveSeq: seqAfterLinger } = useGameStore.getState();
+    expect(seqAfterLinger).toBe(seqAfterActive); // unchanged
   });
 
   it('handles null response from fetchGameLive gracefully', async () => {


### PR DESCRIPTION
## Summary
- When deselecting a game (or switching to another), the 1s live polling continues for 2 more ticks on the previous game before stopping
- Prevents deselected games from appearing instantly stale during transition back to 10s schedule poll
- Linger polls use `undefined` seq to avoid interfering with `lastAcceptedLiveSeq`
- `lingerPolls` count is configurable via options (default 2)

## Pre-Landing Review
No issues found.

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] All tests pass (264 tests, 17 suites)
- [x] New tests: linger completes after deselect, linger during A→B switch, cancel linger on reselect, linger doesn't touch lastAcceptedLiveSeq

🤖 Generated with [Claude Code](https://claude.com/claude-code)