### PR TITLE
feat: audio mastering, mix adjustments, and vinyl crackle engine

### DIFF
--- a/src/audio/composer/effects.js
+++ b/src/audio/composer/effects.js
@@ -3,11 +3,13 @@
  * All layers route through this bus before reaching the master gain.
  *
  * Signal flow:
- *   voices → bus → saturation → tapeFilter (LP 4.8kHz) → Reverb → Compressor → output
+ *   voices → bus → saturation → tapeFilter (LP 4.8kHz) → Reverb → Compressor → makeupGain (+4dB) → Limiter (-1dB) → output
  *   voices → delaySend → PingPongDelay → bus
  *
  * Saturation adds even harmonics (tape warmth).
  * Lowpass filter simulates analog high-frequency rolloff.
+ * Makeup gain restores loudness after compression.
+ * Limiter provides brickwall ceiling for phone/Bluetooth headroom.
  */
 import * as Tone from 'tone';
 
@@ -36,13 +38,19 @@ export class EffectsChain {
       preDelay: 0.12,
     });
 
-    // Compressor: gentle glue, not squash
+    // Compressor: tighter glue — catches reverb tail buildup and EventVoice transients
     this.compressor = new Tone.Compressor({
-      threshold: -15,
-      ratio: 2,
-      attack: 0.2,
-      release: 0.4,
+      threshold: -18,
+      ratio: 3,
+      attack: 0.03,
+      release: 0.25,
     });
+
+    // Makeup gain: restore loudness lost from tighter compression (+4dB)
+    this.makeupGain = new Tone.Gain(1.58);
+
+    // Limiter: brickwall ceiling at -1dB (intersample peak margin for phone DACs/Bluetooth)
+    this.limiter = new Tone.Limiter(-1);
 
     // Delay send: parallel delay for shimmer
     this.delaySend = new Tone.Gain(0);
@@ -52,12 +60,14 @@ export class EffectsChain {
       wet: 1,
     });
 
-    // Wire: bus → saturation → tapeFilter → reverb → compressor → output
+    // Wire: bus → saturation → tapeFilter → reverb → compressor → makeupGain → limiter → output
     this.bus.connect(this.saturation);
     this.saturation.connect(this.tapeFilter);
     this.tapeFilter.connect(this.reverb);
     this.reverb.connect(this.compressor);
-    this.compressor.connect(output);
+    this.compressor.connect(this.makeupGain);
+    this.makeupGain.connect(this.limiter);
+    this.limiter.connect(output);
 
     // Wire: delaySend → delay → bus (parallel send)
     this.delaySend.connect(this.delay);
@@ -72,6 +82,8 @@ export class EffectsChain {
   dispose() {
     this.delay?.dispose();
     this.delaySend?.dispose();
+    this.limiter?.dispose();
+    this.makeupGain?.dispose();
     this.compressor?.dispose();
     this.reverb?.dispose();
     this.tapeFilter?.dispose();
@@ -79,6 +91,8 @@ export class EffectsChain {
     this.bus?.dispose();
     this.delay = null;
     this.delaySend = null;
+    this.limiter = null;
+    this.makeupGain = null;
     this.compressor = null;
     this.reverb = null;
     this.tapeFilter = null;

--- a/src/audio/composer/effects.test.js
+++ b/src/audio/composer/effects.test.js
@@ -1,0 +1,82 @@
+import { EffectsChain } from './effects';
+
+// Track connect calls to verify wiring order
+const mockConnectCalls = [];
+const mockConnect = jest.fn(function (target) {
+  mockConnectCalls.push({ from: this._name, to: target._name });
+  return target;
+});
+
+function mockMakeNode(name) {
+  return { _name: name, connect: mockConnect, dispose: jest.fn(), gain: { value: 1 } };
+}
+
+jest.mock('tone', () => ({
+  Gain: jest.fn((val) => ({ ...mockMakeNode(`Gain(${val})`), gain: { value: val } })),
+  Chebyshev: jest.fn(() => mockMakeNode('Chebyshev')),
+  Filter: jest.fn(() => mockMakeNode('Filter')),
+  Reverb: jest.fn(() => mockMakeNode('Reverb')),
+  Compressor: jest.fn(() => mockMakeNode('Compressor')),
+  PingPongDelay: jest.fn(() => mockMakeNode('PingPongDelay')),
+  Limiter: jest.fn(() => mockMakeNode('Limiter')),
+}));
+
+describe('EffectsChain', () => {
+  beforeEach(() => {
+    mockConnectCalls.length = 0;
+    mockConnect.mockClear();
+  });
+
+  test('wires nodes in correct signal chain order', () => {
+    const output = mockMakeNode('output');
+    new EffectsChain(output);
+
+    // Main chain: bus → saturation → tapeFilter → reverb → compressor → makeupGain → limiter → output
+    const mainChain = mockConnectCalls.filter(
+      (c) => !c.from.includes('PingPongDelay') && c.from !== 'Gain(0)',
+    );
+    const mainNames = mainChain.map((c) => c.from);
+
+    expect(mainNames).toEqual([
+      'Gain(1)',        // bus
+      'Chebyshev',      // saturation
+      'Filter',         // tapeFilter
+      'Reverb',         // reverb
+      'Compressor',     // compressor
+      'Gain(1.58)',     // makeupGain
+      'Limiter',        // limiter
+    ]);
+    // Last node connects to output
+    expect(mainChain[mainChain.length - 1].to).toBe('output');
+  });
+
+  test('wires delay send as parallel path back to bus', () => {
+    const output = mockMakeNode('output');
+    new EffectsChain(output);
+
+    const delayCalls = mockConnectCalls.filter(
+      (c) => c.from === 'Gain(0)' || c.from === 'PingPongDelay',
+    );
+    expect(delayCalls).toEqual([
+      { from: 'Gain(0)', to: 'PingPongDelay' },
+      { from: 'PingPongDelay', to: 'Gain(1)' },
+    ]);
+  });
+
+  test('dispose cleans up all nodes and nulls references', () => {
+    const output = mockMakeNode('output');
+    const chain = new EffectsChain(output);
+
+    chain.dispose();
+
+    expect(chain.bus).toBeNull();
+    expect(chain.saturation).toBeNull();
+    expect(chain.tapeFilter).toBeNull();
+    expect(chain.reverb).toBeNull();
+    expect(chain.compressor).toBeNull();
+    expect(chain.makeupGain).toBeNull();
+    expect(chain.limiter).toBeNull();
+    expect(chain.delay).toBeNull();
+    expect(chain.delaySend).toBeNull();
+  });
+});

--- a/src/audio/composer/layers/BreathLayer.js
+++ b/src/audio/composer/layers/BreathLayer.js
@@ -1,11 +1,12 @@
 /**
  * BreathLayer: ambient texture — breath, tape hiss, and vinyl crackle.
  *
- * Three sub-voices:
+ * Four sub-voices:
  * 1. Breath: filtered pink noise with slow LFO (the "breathing" pad)
  * 2. Tape hiss: high-passed pink noise (constant, very quiet)
- * 3. Vinyl crackle: white noise bursts through a narrow bandpass,
- *    triggered at random intervals (2-6s) with random amplitude
+ * 3. Vinyl surface: continuous quiet white noise through bandpass (the "room tone" of a record)
+ * 4. Vinyl crackle: dense micro-impulses via fast Tone.Loop — mostly tiny
+ *    surface ticks with occasional louder pops. ~10-15 events/sec.
  *
  * Together these create the "analog playback" texture that tells the
  * listener's brain this isn't a digital source.
@@ -16,18 +17,19 @@ import * as Tone from 'tone';
 
 const BREATH_VOLUME = 0.055;
 const HISS_VOLUME = 0.02;
-const CRACKLE_VOLUME = 0.035;
+const SURFACE_VOLUME = 0.012;
+const CRACKLE_VOLUME = 0.04;
 const LFO_MIN_FREQ = 0.08;
 const LFO_MAX_FREQ = 0.125;
-const CRACKLE_MIN_INTERVAL = 2000; // ms
-const CRACKLE_MAX_INTERVAL = 6000;
+const CRACKLE_TICK_INTERVAL = 0.04; // 25 ticks/sec
+const CRACKLE_FIRE_PROBABILITY = 0.45; // ~11 crackles/sec average
+const CRACKLE_POP_PROBABILITY = 0.1; // 10% of crackles are louder pops
 
 export class BreathLayer {
   constructor(output) {
     this.output = output;
     this.suspended = false;
     this.disposed = false;
-    this._crackleTimer = null;
 
     // --- Voice 1: Breath (filtered pink noise with slow LFO) ---
     this.breathNoise = new Tone.Noise('pink');
@@ -69,25 +71,53 @@ export class BreathLayer {
 
     this.hissNoise.start();
 
-    // --- Voice 3: Vinyl crackle (random white noise bursts) ---
-    this.crackleNoise = new Tone.Noise('white');
-    this.crackleNoise.volume.value = -20;
+    // --- Voice 3: Vinyl surface noise (continuous filtered white noise) ---
+    // The quiet "rolling" texture between crackle events — gives the
+    // impression of a needle sitting in the groove at all times.
+    this.surfaceNoise = new Tone.Noise('white');
+    this.surfaceNoise.volume.value = -32;
 
-    // Narrow bandpass centered at 4kHz — the "tick" frequency of dust
-    this.crackleFilter = new Tone.Filter({
-      frequency: 4000,
+    this.surfaceFilter = new Tone.Filter({
+      frequency: 1800,
       type: 'bandpass',
-      Q: 3,
+      Q: 0.8,
     });
 
-    this.crackleGain = new Tone.Gain(0); // silent by default, bursts on
+    this.surfaceGain = new Tone.Gain(SURFACE_VOLUME);
+
+    this.surfaceNoise.connect(this.surfaceFilter);
+    this.surfaceFilter.connect(this.surfaceGain);
+    this.surfaceGain.connect(output);
+
+    this.surfaceNoise.start();
+
+    // --- Voice 4: Vinyl crackle (dense micro-impulse loop) ---
+    // Real vinyl crackle = many short broadband impulses per second.
+    // Amplitude distribution: mostly tiny surface ticks, occasional louder pops.
+    this.crackleNoise = new Tone.Noise('white');
+    this.crackleNoise.volume.value = -18;
+
+    // Wider bandpass than before (Q 1.2 vs 3) centered lower (2.5kHz vs 4kHz)
+    // — real dust impulses are broadband, not narrowly resonant
+    this.crackleFilter = new Tone.Filter({
+      frequency: 2500,
+      type: 'bandpass',
+      Q: 1.2,
+    });
+
+    this.crackleGain = new Tone.Gain(0); // silent between bursts
 
     this.crackleNoise.connect(this.crackleFilter);
     this.crackleFilter.connect(this.crackleGain);
     this.crackleGain.connect(output);
 
     this.crackleNoise.start();
-    this._scheduleCrackle();
+
+    // Fast loop fires micro-bursts probabilistically
+    this.crackleLoop = new Tone.Loop((time) => {
+      this._tickCrackle(time);
+    }, CRACKLE_TICK_INTERVAL);
+    this.crackleLoop.start(Tone.now());
   }
 
   /**
@@ -112,22 +142,23 @@ export class BreathLayer {
     this.suspended = true;
     this.breathNoise?.stop();
     this.hissNoise?.stop();
+    this.surfaceNoise?.stop();
     this.crackleNoise?.stop();
-    this._clearCrackle();
+    this.crackleLoop?.stop();
   }
 
   resume() {
     this.suspended = false;
     this.breathNoise?.start();
     this.hissNoise?.start();
+    this.surfaceNoise?.start();
     this.crackleNoise?.start();
-    this._scheduleCrackle();
+    this.crackleLoop?.start(Tone.now());
   }
 
   dispose() {
     this.suspended = true;
     this.disposed = true;
-    this._clearCrackle();
 
     this.breathNoise?.stop();
     this.breathNoise?.dispose();
@@ -139,6 +170,13 @@ export class BreathLayer {
     this.hissFilter?.dispose();
     this.hissGain?.dispose();
 
+    this.surfaceNoise?.stop();
+    this.surfaceNoise?.dispose();
+    this.surfaceFilter?.dispose();
+    this.surfaceGain?.dispose();
+
+    this.crackleLoop?.stop();
+    this.crackleLoop?.dispose();
     this.crackleNoise?.stop();
     this.crackleNoise?.dispose();
     this.crackleFilter?.dispose();
@@ -150,50 +188,50 @@ export class BreathLayer {
     this.hissNoise = null;
     this.hissFilter = null;
     this.hissGain = null;
+    this.surfaceNoise = null;
+    this.surfaceFilter = null;
+    this.surfaceGain = null;
+    this.crackleLoop = null;
     this.crackleNoise = null;
     this.crackleFilter = null;
     this.crackleGain = null;
   }
 
-  // --- Private: crackle scheduling ---
+  // --- Private: crackle engine ---
 
-  /** Schedule the next random crackle burst. */
-  _scheduleCrackle() {
-    if (this.suspended || this.disposed) return;
+  /**
+   * Called 25x/sec by Tone.Loop. Probabilistically fires a micro-burst
+   * of white noise (1-4ms) to simulate vinyl dust/surface imperfections.
+   *
+   * Amplitude distribution models real vinyl:
+   * - 90% are tiny surface ticks (0.05-0.25x volume)
+   * - 10% are audible pops (0.5-1.0x volume)
+   * - Occasional double-click (30% chance after a pop)
+   */
+  _tickCrackle(time) {
+    if (this.disposed || !this.crackleGain) return;
 
-    const delay = CRACKLE_MIN_INTERVAL +
-      Math.random() * (CRACKLE_MAX_INTERVAL - CRACKLE_MIN_INTERVAL);
+    if (Math.random() > CRACKLE_FIRE_PROBABILITY) return;
 
-    this._crackleTimer = setTimeout(() => this._fireCrackle(), delay);
-  }
+    // Amplitude: mostly tiny, occasionally loud
+    const isPop = Math.random() < CRACKLE_POP_PROBABILITY;
+    const amplitude = isPop
+      ? CRACKLE_VOLUME * (0.5 + Math.random() * 0.5)
+      : CRACKLE_VOLUME * (0.05 + Math.random() * 0.2);
 
-  /** Fire a single crackle: quick gain burst then silence. */
-  _fireCrackle() {
-    if (this.suspended || this.disposed || !this.crackleGain) return;
+    // Burst duration: 1-4ms (real dust impulses are < 5ms)
+    const duration = 0.001 + Math.random() * 0.003;
 
-    // Random amplitude for natural variation
-    const amplitude = CRACKLE_VOLUME * (0.3 + Math.random() * 0.7);
-    const now = Tone.now();
+    this.crackleGain.gain.setValueAtTime(amplitude, time);
+    this.crackleGain.gain.setValueAtTime(0, time + duration);
 
-    // Very short burst: 5-15ms
-    this.crackleGain.gain.setValueAtTime(amplitude, now);
-    this.crackleGain.gain.setValueAtTime(0, now + 0.005 + Math.random() * 0.01);
-
-    // Sometimes fire a second click 20-50ms later (double crackle)
-    if (Math.random() < 0.3) {
-      const secondAmp = amplitude * (0.3 + Math.random() * 0.4);
-      const secondTime = now + 0.02 + Math.random() * 0.03;
-      this.crackleGain.gain.setValueAtTime(secondAmp, secondTime);
-      this.crackleGain.gain.setValueAtTime(0, secondTime + 0.005 + Math.random() * 0.008);
-    }
-
-    this._scheduleCrackle();
-  }
-
-  _clearCrackle() {
-    if (this._crackleTimer) {
-      clearTimeout(this._crackleTimer);
-      this._crackleTimer = null;
+    // Pops sometimes have a trailing click 15-40ms later
+    if (isPop && Math.random() < 0.3) {
+      const echoAmp = amplitude * (0.2 + Math.random() * 0.3);
+      const echoTime = time + 0.015 + Math.random() * 0.025;
+      const echoDuration = 0.001 + Math.random() * 0.002;
+      this.crackleGain.gain.setValueAtTime(echoAmp, echoTime);
+      this.crackleGain.gain.setValueAtTime(0, echoTime + echoDuration);
     }
   }
 }

--- a/src/audio/composer/layers/EventVoice.js
+++ b/src/audio/composer/layers/EventVoice.js
@@ -201,7 +201,7 @@ export class EventVoice {
   /** High bell tone — upper scale tone. */
   _playStrike(harmony) {
     const { scaleTones } = harmony;
-    const highTones = scaleTones.filter(t => t >= 72);
+    const highTones = scaleTones.filter(t => t >= 67);
     const tone = highTones.length > 0
       ? highTones[Math.floor(Math.random() * highTones.length)]
       : scaleTones[scaleTones.length - 1];

--- a/src/audio/composer/layers/PulsePool.js
+++ b/src/audio/composer/layers/PulsePool.js
@@ -71,7 +71,7 @@ export class PulsePool {
     this.running = true;
 
     // Fade in
-    this.gain.gain.rampTo(0.05, fadeIn);
+    this.gain.gain.rampTo(0.09, fadeIn);
 
     // Start the loop
     this.loop.start(Tone.now());
@@ -142,7 +142,7 @@ export class PulsePool {
     }
 
     // Pick tones in the mid range for clarity
-    const midTones = scaleTones.filter(t => t >= 60 && t <= 84);
+    const midTones = scaleTones.filter(t => t >= 60 && t <= 76);
     const pool = midTones.length >= 3 ? midTones : scaleTones;
 
     // Generate pattern: pick notes somewhat randomly but musically


### PR DESCRIPTION
## Summary
- Add mastering chain: tighter compressor (-18dB/3:1), +4dB makeup gain, -1dB brickwall limiter
- Boost pulse pool gain (0.05 → 0.09) to foreground Reich-style phasing patterns
- Lower strike note floor (C5 → G4) and pulse ceiling (C6 → E5) to reduce FM bell shrillness
- Replace sparse setTimeout crackle with dense Tone.Loop engine (~11 crackles/sec)
- Add continuous vinyl surface noise voice for rolling "needle in groove" texture
- Add EffectsChain wiring test

## Pre-Landing Review
Pre-Landing Review: 0 critical issues, 0 informational issues on audio changes.

## Test plan
- [x] All tests pass (276 tests, 19 suites)
- [x] Build succeeds
- [ ] Manual listening test on headphones

🤖 Generated with [Claude Code](https://claude.com/claude-code)