### PR TITLE
fix: prevent stale poll data from regressing game state

### DIFF
--- a/src/hooks/useLiveGamePolling.js
+++ b/src/hooks/useLiveGamePolling.js
@@ -1,14 +1,11 @@
-import { useEffect, useRef } from 'react';
 import { fetchGameLive } from '../services/api';
 import { useGameStore } from '../store/gameStore';
 import { adaptLiveFeed } from '../utils/adaptLiveFeed';
 import { usePollingLoop } from './usePollingLoop';
 
-export function useLiveGamePolling(activeGameId, { interval = 1000, lingerPolls = 2 } = {}) {
+export function useLiveGamePolling(activeGameId, { interval = 1000 } = {}) {
   const ingestGame = useGameStore((s) => s.ingestGame);
-  const prevGameIdRef = useRef(null);
 
-  // Main polling — unchanged behavior
   usePollingLoop(() => {
     const seq = Date.now();
     return fetchGameLive(activeGameId).then((raw) => {
@@ -16,41 +13,6 @@ export function useLiveGamePolling(activeGameId, { interval = 1000, lingerPolls 
       if (adapted) ingestGame(adapted, seq);
     });
   }, { interval, enabled: !!activeGameId });
-
-  // Linger polling — fire N more polls for the previous game after deselection
-  useEffect(() => {
-    const prevId = prevGameIdRef.current;
-    prevGameIdRef.current = activeGameId;
-
-    // Only linger if we had a previous game and it changed
-    if (!prevId || prevId === activeGameId) return;
-
-    let remaining = lingerPolls;
-    let mounted = true;
-    let timer;
-
-    async function tick() {
-      if (!mounted || remaining <= 0) return;
-      remaining--;
-      try {
-        const raw = await fetchGameLive(prevId);
-        const adapted = adaptLiveFeed(raw);
-        if (adapted) ingestGame(adapted, undefined); // no seq — avoid lastAcceptedLiveSeq interference
-      } catch (err) {
-        console.error('[useLiveGamePolling] linger poll error:', err);
-      }
-      if (mounted && remaining > 0) {
-        timer = setTimeout(tick, interval);
-      }
-    }
-
-    timer = setTimeout(tick, interval); // first linger poll after one interval
-
-    return () => {
-      mounted = false;
-      clearTimeout(timer);
-    };
-  }, [activeGameId, interval, lingerPolls, ingestGame]);
 }
 
 export default useLiveGamePolling;

--- a/src/hooks/useLiveGamePolling.test.js
+++ b/src/hooks/useLiveGamePolling.test.js
@@ -17,6 +17,7 @@ beforeEach(() => {
     lastAcceptedLiveSeq: 0,
     lastUpdatedAt: null,
     pollError: null,
+    livePolledAt: {},
   });
 });
 
@@ -72,103 +73,54 @@ describe('useLiveGamePolling', () => {
     expect(fetchGameLive).not.toHaveBeenCalled();
   });
 
-  it('linger-polls prev game after deselection then stops', async () => {
+  it('stops polling when activeGameId becomes null', async () => {
     fetchGameLive.mockResolvedValue(makeLiveFeedResponse(718405));
 
     const { rerender } = renderHook(
-      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000, lingerPolls: 2 }),
+      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000 }),
       { initialProps: { gameId: '718405' } },
     );
 
-    // Initial active poll
     await act(async () => {});
     expect(fetchGameLive).toHaveBeenCalledTimes(1);
 
-    // Deselect — linger starts
+    // Deselect — polling stops, no linger
     rerender({ gameId: null });
 
-    // First linger poll after 1 interval
-    await act(async () => { jest.advanceTimersByTime(1000); });
-    await act(async () => {});
-    expect(fetchGameLive).toHaveBeenCalledTimes(2);
-    expect(fetchGameLive).toHaveBeenLastCalledWith('718405');
-
-    // Second linger poll after another interval
-    await act(async () => { jest.advanceTimersByTime(1000); });
-    await act(async () => {});
-    expect(fetchGameLive).toHaveBeenCalledTimes(3);
-
-    // No more polls after linger exhausted
     await act(async () => { jest.advanceTimersByTime(5000); });
     await act(async () => {});
-    expect(fetchGameLive).toHaveBeenCalledTimes(3);
+
+    // No additional polls after deselection
+    expect(fetchGameLive).toHaveBeenCalledTimes(1);
   });
 
-  it('linger-polls prev game when switching A→B', async () => {
+  it('switches polling to new game when activeGameId changes', async () => {
     fetchGameLive.mockImplementation((id) =>
       Promise.resolve(makeLiveFeedResponse(Number(id))),
     );
 
     const { rerender } = renderHook(
-      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000, lingerPolls: 2 }),
+      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000 }),
       { initialProps: { gameId: '111' } },
     );
 
-    // Initial active poll for game 111
+    // Initial active poll for 111
     await act(async () => {});
-    expect(fetchGameLive).toHaveBeenCalledTimes(1);
     expect(fetchGameLive).toHaveBeenCalledWith('111');
 
-    // Switch to game 222 — active polls 222, linger polls 111
+    // Switch to game 222 — need to advance timer for new poll loop to fire
     rerender({ gameId: '222' });
-    await act(async () => {}); // immediate active poll for 222
-
-    // After 1 interval: second active poll for 222 + first linger poll for 111
     await act(async () => { jest.advanceTimersByTime(1000); });
     await act(async () => {});
 
-    // After another interval: third active poll for 222 + second linger poll for 111
+    expect(fetchGameLive).toHaveBeenCalledWith('222');
+
+    // After another interval, only 222 is polled (no linger polls for 111)
     await act(async () => { jest.advanceTimersByTime(1000); });
     await act(async () => {});
 
-    const calls = fetchGameLive.mock.calls.map(([id]) => id);
-    expect(calls.filter((id) => id === '222').length).toBeGreaterThanOrEqual(2);
-    expect(calls.filter((id) => id === '111').length).toBeGreaterThanOrEqual(2);
-  });
-
-  it('cancels linger when a new game is selected mid-linger', async () => {
-    fetchGameLive.mockImplementation((id) =>
-      Promise.resolve(makeLiveFeedResponse(Number(id))),
-    );
-
-    const { rerender } = renderHook(
-      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000, lingerPolls: 2 }),
-      { initialProps: { gameId: '111' } },
-    );
-
-    await act(async () => {}); // initial poll
-
-    // Deselect — linger starts for 111
-    rerender({ gameId: null });
-
-    // First linger poll fires
-    await act(async () => { jest.advanceTimersByTime(1000); });
-    await act(async () => {});
-
-    const callsBeforeReselect = fetchGameLive.mock.calls.length;
-
-    // Select game 222 — should cancel linger for 111, start linger for null (no-op since prev=null after cleanup)
-    rerender({ gameId: '222' });
-    await act(async () => {}); // immediate active poll for 222
-
-    // Advance several intervals — should only see 222 polls, no more 111 linger polls
-    await act(async () => { jest.advanceTimersByTime(5000); });
-    await act(async () => {});
-
-    const callsAfterReselect = fetchGameLive.mock.calls.slice(callsBeforeReselect);
-    const lingerCallsFor111 = callsAfterReselect.filter(([id]) => id === '111');
-    // At most 1 more linger poll for 111 (the one already scheduled), but the cleanup should prevent the second
-    expect(lingerCallsFor111.length).toBeLessThanOrEqual(1);
+    const recentCalls = fetchGameLive.mock.calls.slice(-2).map(([id]) => id);
+    expect(recentCalls.every((id) => id === '222')).toBe(true);
   });
 
   it('sets pollError on fetch failure', async () => {
@@ -201,28 +153,6 @@ describe('useLiveGamePolling', () => {
     const { lastAcceptedLiveSeq, lastAcceptedSeq } = useGameStore.getState();
     expect(lastAcceptedLiveSeq).toBeGreaterThan(0);
     expect(lastAcceptedSeq).toBe(0); // schedule tier untouched
-  });
-
-  it('linger polls do not update lastAcceptedLiveSeq', async () => {
-    fetchGameLive.mockResolvedValue(makeLiveFeedResponse(718405));
-
-    const { rerender } = renderHook(
-      ({ gameId }) => useLiveGamePolling(gameId, { interval: 1000, lingerPolls: 2 }),
-      { initialProps: { gameId: '718405' } },
-    );
-
-    await act(async () => {});
-    const { lastAcceptedLiveSeq: seqAfterActive } = useGameStore.getState();
-
-    // Deselect — linger starts
-    rerender({ gameId: null });
-
-    // First linger poll
-    await act(async () => { jest.advanceTimersByTime(1000); });
-    await act(async () => {});
-
-    const { lastAcceptedLiveSeq: seqAfterLinger } = useGameStore.getState();
-    expect(seqAfterLinger).toBe(seqAfterActive); // unchanged
   });
 
   it('handles null response from fetchGameLive gracefully', async () => {

--- a/src/store/gameStore.js
+++ b/src/store/gameStore.js
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 import { normalizeGame } from '../utils/normalizeGame';
 
+// How long after a game's last live-feed update the schedule tier is blocked
+// from overwriting it. 30s ≈ 3× the schedule poll interval (10s), so schedule
+// data will have caught up by the time the window expires.
+const LIVE_PROTECTION_MS = 30_000;
+
 export const useGameStore = create((set, get) => ({
   games: {},
   activeGameId: null,
@@ -8,11 +13,18 @@ export const useGameStore = create((set, get) => ({
   lastAcceptedLiveSeq: 0,
   lastUpdatedAt: null,
   pollError: null,
+  livePolledAt: {},   // gameId → timestamp of last live feed update
 
+  // Schedule-tier batch ingest. Three layers protect against stale data:
+  //
+  //   Layer 1: activeGameId skip   — blocks ALL schedule data for active game
+  //   Layer 2: livePolledAt window  — blocks schedule data for 30s after last live poll
+  //   Layer 3: gameNotBehind        — blocks inning/out regression permanently
+  //
   ingestGames: (rawGames, seq) => {
     if (!Array.isArray(rawGames)) return;
 
-    const { games: prev, activeGameId, lastAcceptedSeq } = get();
+    const { games: prev, activeGameId, lastAcceptedSeq, livePolledAt } = get();
 
     // Drop stale responses — seq must be strictly greater
     if (seq !== undefined && seq <= lastAcceptedSeq) {
@@ -20,6 +32,7 @@ export const useGameStore = create((set, get) => ({
       return;
     }
 
+    const now = Date.now();
     const next = {};
 
     for (const raw of rawGames) {
@@ -28,13 +41,25 @@ export const useGameStore = create((set, get) => ({
 
       const id = normalized.gameId;
 
-      // Skip active game when live polling is active — live feed has fresher data
+      // Layer 1: skip active game when live polling is active — live feed has fresher data
       if (id === activeGameId && get().lastAcceptedLiveSeq > 0) {
         next[id] = prev[id];
         continue;
       }
 
+      // Layer 2: skip recently live-polled games (full field protection window)
+      const liveTs = livePolledAt[id];
+      if (liveTs && now - liveTs < LIVE_PROTECTION_MS) {
+        next[id] = prev[id];
+        continue;
+      }
+
+      // Layer 3: reject inning/out regression
       const existing = prev[id];
+      if (existing && !gameNotBehind(existing, normalized)) {
+        next[id] = existing;
+        continue;
+      }
 
       // Keep old reference if nothing changed (referential stability)
       if (existing && gameEqual(existing, normalized)) {
@@ -55,10 +80,17 @@ export const useGameStore = create((set, get) => ({
     const gamesChanged = prevKeys.length !== nextKeys.length ||
       nextKeys.some(k => next[k] !== prev[k]);
 
+    // Prune expired livePolledAt entries
+    const prunedLivePolledAt = {};
+    for (const [gid, ts] of Object.entries(livePolledAt)) {
+      if (now - ts < LIVE_PROTECTION_MS) prunedLivePolledAt[gid] = ts;
+    }
+
     const metadata = {
       lastAcceptedSeq: seq ?? get().lastAcceptedSeq,
       lastUpdatedAt: Date.now(),
       pollError: null,
+      livePolledAt: prunedLivePolledAt,
     };
 
     if (gamesChanged) {
@@ -92,7 +124,14 @@ export const useGameStore = create((set, get) => ({
       lastAcceptedLiveSeq: seq ?? get().lastAcceptedLiveSeq,
       lastUpdatedAt: Date.now(),
       pollError: null,
+      livePolledAt: { ...get().livePolledAt, [id]: Date.now() },
     };
+
+    // Layer 3: reject inning/out regression from any source
+    if (existing && !gameNotBehind(existing, normalized)) {
+      set(metadata);
+      return;
+    }
 
     if (existing && gameEqual(existing, normalized)) {
       set(metadata);
@@ -151,7 +190,18 @@ function gameEqual(a, b) {
   );
 }
 
+// Returns true if incoming is NOT behind existing in game progression.
+// Progression: inning half (inning × 2 + isTop), then outs within that half.
+// Only enforced for Live→Live — status transitions (e.g. Live→Final) always accepted.
+function gameNotBehind(existing, incoming) {
+  if (existing.status !== 'Live' || incoming.status !== 'Live') return true;
+  const eHalf = existing.inning * 2 + (existing.isTopInning ? 0 : 1);
+  const iHalf = incoming.inning * 2 + (incoming.isTopInning ? 0 : 1);
+  if (iHalf !== eHalf) return iHalf > eHalf;
+  return incoming.outs >= existing.outs;
+}
+
 // Exported for testing
-export { gameEqual };
+export { gameEqual, gameNotBehind, LIVE_PROTECTION_MS };
 
 export default useGameStore;

--- a/src/store/gameStore.test.js
+++ b/src/store/gameStore.test.js
@@ -1,4 +1,4 @@
-import { useGameStore, gameEqual } from './gameStore';
+import { useGameStore, gameEqual, gameNotBehind, LIVE_PROTECTION_MS } from './gameStore';
 import { normalizeGame } from '../utils/normalizeGame';
 
 // Helper to reset store between tests
@@ -10,6 +10,7 @@ beforeEach(() => {
     lastAcceptedLiveSeq: 0,
     lastUpdatedAt: null,
     pollError: null,
+    livePolledAt: {},
   });
 });
 
@@ -596,6 +597,277 @@ describe('gameStore', () => {
       })]);
 
       expect(useGameStore.getState().games['200'].homeScore).toBe(7);
+    });
+  });
+
+  describe('gameNotBehind', () => {
+    const makeLive = (inning, isTopInning, outs) => ({
+      status: 'Live', inning, isTopInning, outs,
+    });
+
+    it('returns true when existing is not Live', () => {
+      expect(gameNotBehind(
+        { status: 'Preview', inning: 0, isTopInning: true, outs: 0 },
+        { status: 'Live', inning: 1, isTopInning: true, outs: 0 },
+      )).toBe(true);
+    });
+
+    it('returns true when incoming is not Live', () => {
+      expect(gameNotBehind(
+        makeLive(5, true, 2),
+        { status: 'Final', inning: 9, isTopInning: false, outs: 3 },
+      )).toBe(true);
+    });
+
+    it('returns true when incoming is ahead in inning half', () => {
+      expect(gameNotBehind(makeLive(3, false, 2), makeLive(4, true, 0))).toBe(true);
+    });
+
+    it('returns false when incoming is behind in inning half', () => {
+      expect(gameNotBehind(makeLive(4, true, 0), makeLive(3, false, 2))).toBe(false);
+    });
+
+    it('returns true when same half and outs are equal', () => {
+      expect(gameNotBehind(makeLive(4, true, 1), makeLive(4, true, 1))).toBe(true);
+    });
+
+    it('returns true when same half and incoming has more outs', () => {
+      expect(gameNotBehind(makeLive(4, true, 1), makeLive(4, true, 2))).toBe(true);
+    });
+
+    it('returns false when same half and incoming has fewer outs', () => {
+      expect(gameNotBehind(makeLive(4, true, 2), makeLive(4, true, 1))).toBe(false);
+    });
+  });
+
+  describe('livePolledAt protection window (Layer 2)', () => {
+    it('rejects schedule data for game within protection window', () => {
+      const { ingestGames, ingestGame } = useGameStore.getState();
+
+      // Seed game 100, then live-poll it (sets livePolledAt)
+      ingestGames([makeRawGame(100)]);
+      ingestGame(makeRawGame(100, {
+        teams: {
+          home: { team: { id: 1, name: 'Yankees', abbreviation: 'NYY' }, score: 5 },
+          away: { team: { id: 2, name: 'Red Sox', abbreviation: 'BOS' }, score: 0 },
+        },
+      }), 500);
+
+      // Deselect (no activeGameId) — game is now protected by livePolledAt
+      useGameStore.setState({ activeGameId: null });
+
+      // Schedule returns stale data — should be blocked by Layer 2
+      ingestGames([makeRawGame(100, {
+        teams: {
+          home: { team: { id: 1, name: 'Yankees', abbreviation: 'NYY' }, score: 2 },
+          away: { team: { id: 2, name: 'Red Sox', abbreviation: 'BOS' }, score: 0 },
+        },
+      })]);
+
+      expect(useGameStore.getState().games['100'].homeScore).toBe(5);
+    });
+
+    it('accepts schedule data for game outside protection window', () => {
+      const { ingestGames, ingestGame } = useGameStore.getState();
+
+      ingestGames([makeRawGame(100)]);
+      ingestGame(makeRawGame(100), 500);
+
+      // Simulate expired window by backdating livePolledAt
+      useGameStore.setState({
+        activeGameId: null,
+        livePolledAt: { '100': Date.now() - LIVE_PROTECTION_MS - 1000 },
+      });
+
+      // Schedule with updated score — should be accepted (window expired)
+      ingestGames([makeRawGame(100, {
+        teams: {
+          home: { team: { id: 1, name: 'Yankees', abbreviation: 'NYY' }, score: 3 },
+          away: { team: { id: 2, name: 'Red Sox', abbreviation: 'BOS' }, score: 0 },
+        },
+      })]);
+
+      expect(useGameStore.getState().games['100'].homeScore).toBe(3);
+    });
+
+    it('prunes expired livePolledAt entries', () => {
+      const { ingestGames } = useGameStore.getState();
+
+      useGameStore.setState({
+        livePolledAt: {
+          '100': Date.now() - LIVE_PROTECTION_MS - 1000,  // expired
+          '200': Date.now(),                                // fresh
+        },
+      });
+
+      ingestGames([makeRawGame(100)]);
+
+      const { livePolledAt } = useGameStore.getState();
+      expect(livePolledAt['100']).toBeUndefined();
+      expect(livePolledAt['200']).toBeDefined();
+    });
+
+    it('does not block non-live-polled games', () => {
+      const { ingestGames } = useGameStore.getState();
+
+      ingestGames([makeRawGame(100)]);
+
+      // Schedule updates game 100 (never live-polled) — should work
+      ingestGames([makeRawGame(100, {
+        teams: {
+          home: { team: { id: 1, name: 'Yankees', abbreviation: 'NYY' }, score: 4 },
+          away: { team: { id: 2, name: 'Red Sox', abbreviation: 'BOS' }, score: 0 },
+        },
+      })]);
+
+      expect(useGameStore.getState().games['100'].homeScore).toBe(4);
+    });
+  });
+
+  describe('gameNotBehind in ingestGames (Layer 3)', () => {
+    it('rejects inning regression on deselected game past protection window', () => {
+      const { ingestGames } = useGameStore.getState();
+
+      // Seed game at top of 4th
+      ingestGames([makeRawGame(100, {
+        linescore: { currentInning: 4, isTopInning: true, inningState: 'Top', balls: 0, strikes: 0, outs: 1, offense: {} },
+      })]);
+
+      // Schedule returns bottom of 3rd — should be rejected by Layer 3
+      ingestGames([makeRawGame(100, {
+        linescore: { currentInning: 3, isTopInning: false, inningState: 'Bottom', balls: 0, strikes: 0, outs: 2, offense: {} },
+      })]);
+
+      expect(useGameStore.getState().games['100'].inning).toBe(4);
+      expect(useGameStore.getState().games['100'].isTopInning).toBe(true);
+    });
+
+    it('rejects out regression on deselected game past protection window', () => {
+      const { ingestGames } = useGameStore.getState();
+
+      // Seed game at top of 4th, 2 outs
+      ingestGames([makeRawGame(100, {
+        linescore: { currentInning: 4, isTopInning: true, inningState: 'Top', balls: 0, strikes: 0, outs: 2, offense: {} },
+      })]);
+
+      // Schedule returns same half but only 1 out — should be rejected
+      ingestGames([makeRawGame(100, {
+        linescore: { currentInning: 4, isTopInning: true, inningState: 'Top', balls: 0, strikes: 0, outs: 1, offense: {} },
+      })]);
+
+      expect(useGameStore.getState().games['100'].outs).toBe(2);
+    });
+
+    it('accepts schedule data that has caught up', () => {
+      const { ingestGames } = useGameStore.getState();
+
+      ingestGames([makeRawGame(100, {
+        linescore: { currentInning: 4, isTopInning: true, inningState: 'Top', balls: 0, strikes: 0, outs: 1, offense: {} },
+      })]);
+
+      // Schedule returns same inning, same or more outs — accepted
+      ingestGames([makeRawGame(100, {
+        linescore: { currentInning: 4, isTopInning: true, inningState: 'Top', balls: 2, strikes: 1, outs: 2, offense: {} },
+      })]);
+
+      expect(useGameStore.getState().games['100'].outs).toBe(2);
+      expect(useGameStore.getState().games['100'].balls).toBe(2);
+    });
+  });
+
+  describe('gameNotBehind in ingestGame (Layer 3 for live tier)', () => {
+    it('rejects late live response behind current store state', () => {
+      const { ingestGames, ingestGame } = useGameStore.getState();
+
+      ingestGames([makeRawGame(100, {
+        linescore: { currentInning: 5, isTopInning: true, inningState: 'Top', balls: 0, strikes: 0, outs: 0, offense: {} },
+      })]);
+
+      // Late live response from inning 4 — should be rejected
+      ingestGame(makeRawGame(100, {
+        linescore: { currentInning: 4, isTopInning: false, inningState: 'Bottom', balls: 1, strikes: 2, outs: 2, offense: {} },
+      }), undefined);
+
+      expect(useGameStore.getState().games['100'].inning).toBe(5);
+    });
+
+    it('sets livePolledAt on successful live ingest', () => {
+      const { ingestGames, ingestGame } = useGameStore.getState();
+
+      ingestGames([makeRawGame(100)]);
+      const before = Date.now();
+      ingestGame(makeRawGame(100), 500);
+
+      const { livePolledAt } = useGameStore.getState();
+      expect(livePolledAt['100']).toBeGreaterThanOrEqual(before);
+      expect(livePolledAt['100']).toBeLessThanOrEqual(Date.now());
+    });
+  });
+
+  describe('end-to-end: rapid game switching A→B→A', () => {
+    it('never regresses game A during switch', () => {
+      const { ingestGames, ingestGame, setActiveGame } = useGameStore.getState();
+
+      // Seed both games
+      ingestGames([makeRawGame(100), makeRawGame(200)]);
+
+      // Select game A, live-poll to top of 4th
+      setActiveGame(100);
+      ingestGame(makeRawGame(100, {
+        linescore: { currentInning: 4, isTopInning: true, inningState: 'Top', balls: 2, strikes: 1, outs: 1, offense: {} },
+      }), 1000);
+      expect(useGameStore.getState().games['100'].inning).toBe(4);
+
+      // Switch to game B
+      setActiveGame(200);
+      ingestGame(makeRawGame(200, {
+        linescore: { currentInning: 6, isTopInning: false, inningState: 'Bottom', balls: 0, strikes: 0, outs: 0, offense: {} },
+      }), 2000);
+
+      // Schedule returns stale data for game A (bottom 3rd) — blocked by Layer 2
+      ingestGames([
+        makeRawGame(100, {
+          linescore: { currentInning: 3, isTopInning: false, inningState: 'Bottom', balls: 0, strikes: 0, outs: 2, offense: {} },
+        }),
+        makeRawGame(200),
+      ]);
+
+      expect(useGameStore.getState().games['100'].inning).toBe(4);
+      expect(useGameStore.getState().games['100'].isTopInning).toBe(true);
+
+      // Switch back to game A — live poll picks up
+      setActiveGame(100);
+      ingestGame(makeRawGame(100, {
+        linescore: { currentInning: 4, isTopInning: true, inningState: 'Top', balls: 3, strikes: 1, outs: 1, offense: {} },
+      }), 3000);
+
+      // A still at inning 4, count advanced
+      expect(useGameStore.getState().games['100'].inning).toBe(4);
+      expect(useGameStore.getState().games['100'].balls).toBe(3);
+    });
+  });
+
+  describe('end-to-end: deselect with within-out stale count', () => {
+    it('blocks stale count within same out via protection window', () => {
+      const { ingestGames, ingestGame } = useGameStore.getState();
+
+      ingestGames([makeRawGame(100)]);
+
+      // Live-poll to inning 3, 1 out, count 2-1
+      ingestGame(makeRawGame(100, {
+        linescore: { currentInning: 3, isTopInning: true, inningState: 'Top', balls: 2, strikes: 1, outs: 1, offense: {} },
+      }), 500);
+
+      // Deselect
+      useGameStore.setState({ activeGameId: null });
+
+      // Schedule returns same inning/outs but stale count 0-0 — blocked by Layer 2 (within window)
+      ingestGames([makeRawGame(100, {
+        linescore: { currentInning: 3, isTopInning: true, inningState: 'Top', balls: 0, strikes: 0, outs: 1, offense: {} },
+      })]);
+
+      expect(useGameStore.getState().games['100'].balls).toBe(2);
+      expect(useGameStore.getState().games['100'].strikes).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add three-layer stale data protection in the Zustand store to prevent schedule-tier polling from overwriting fresher live feed data
- **Layer 1** (existing): `activeGameId` skip blocks all schedule data for the active game
- **Layer 2** (new): `livePolledAt` time window blocks schedule data for 30s after last live poll — protects count, runners, all fields
- **Layer 3** (new): `gameNotBehind` monotonic check permanently rejects inning/out regression from any data source
- Remove linger polling (PR #10) — store-level protection makes it unnecessary

## Pre-Landing Review
No issues found.

## Test plan
- [x] All tests pass (289 tests, 18 suites)
- [x] Build succeeds
- [x] `gameNotBehind` unit tests: 7 cases covering all progression comparisons
- [x] `livePolledAt` protection window: 4 cases (within window, expired, pruning, non-live-polled)
- [x] Layer 3 in both ingest paths: 5 cases (inning regression, out regression, caught up, late live response)
- [x] End-to-end scenarios: rapid A→B→A switching, within-out stale count protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)