### PR TITLE
fix: resolve mobile Safari gradient seam

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,6 +13,8 @@ body {
     overflow-x: hidden;
     background-color: #121212;
     color: #ffffff;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
   }
   
   


### PR DESCRIPTION
## Summary
- Add `translateZ(0)` to body element to promote it to a GPU compositing layer
- Fixes visible horizontal seam in mobile Safari caused by `filter: drop-shadow()` creating separate compositing layers with visible boundaries
- No visual change to shadows or any other styling — preserves existing `drop-shadow` aesthetic

## Pre-Landing Review
No issues found.

## Test plan
- [x] All Jest tests pass (292 tests, 19 suites)
- [x] `npm run build` succeeds
- [ ] Verify on real mobile Safari that gradient seam is gone
- [ ] Verify shadows still render correctly on cards, buttons, chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)