### PR TITLE
fix: use box-shadow on mobile to prevent Safari compositing seam

### DIFF
--- a/src/components/GameCard.js
+++ b/src/components/GameCard.js
@@ -27,6 +27,10 @@ const cardStyles = {
     '&:hover': {
       borderColor: 'white',
       filter: 'drop-shadow(15px 10px 5px rgba(255, 255, 255, 0.45))',
+      '@media (max-width: 600px)': {
+        filter: 'none',
+        boxShadow: '15px 10px 5px rgba(255, 255, 255, 0.45)',
+      },
     }
   },
   static: {
@@ -34,6 +38,10 @@ const cardStyles = {
   },
   selected: {
     filter: 'drop-shadow(15px 10px 5px rgba(255, 255, 255, 0.8)) !important',
+    '@media (max-width: 600px)': {
+      filter: 'none !important',
+      boxShadow: '15px 10px 5px rgba(255, 255, 255, 0.8) !important',
+    },
   }
 };
 

--- a/src/components/ThemeRegistry.js
+++ b/src/components/ThemeRegistry.js
@@ -52,8 +52,16 @@ const theme = createTheme({
           background: 'linear-gradient(145deg, #2d5a27, #1d3a19)',
           filter: 'drop-shadow(15px 10px 5px rgba(255, 255, 255, 0.3))',
           transition: 'all 0.3s ease',
+          '@media (max-width: 600px)': {
+            filter: 'none',
+            boxShadow: '15px 10px 5px rgba(255, 255, 255, 0.3)',
+          },
           '&:not(.static-card):hover': {
             filter: 'drop-shadow(15px 10px 5px rgba(255, 255, 255, 0.6))',
+            '@media (max-width: 600px)': {
+              filter: 'none',
+              boxShadow: '15px 10px 5px rgba(255, 255, 255, 0.6)',
+            },
           },
         },
       },


### PR DESCRIPTION
## Summary
- On mobile (≤600px), swap `filter: drop-shadow()` for `box-shadow` on game cards to prevent a visible seam between compositing layers in mobile Safari
- Desktop retains the existing `drop-shadow` filter unchanged
- Applied to MuiCard theme overrides (ThemeRegistry.js) and card interaction states (GameCard.js)

## Pre-Landing Review
No issues found.

## Test plan
- [x] All Jest tests pass (292 tests)
- [x] Production build succeeds
- [ ] Visual verification on mobile Safari — no seam between cards and gradient background
- [ ] Visual verification on desktop — drop-shadow renders as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)