### PR TITLE
feat: use baseball emoji as favicon and app icons

### DIFF
--- a/app/apple-icon.js
+++ b/app/apple-icon.js
@@ -12,28 +12,10 @@ export default function AppleIcon() {
         justifyContent: 'center',
         width: '100%',
         height: '100%',
-        backgroundColor: '#1a2f16',
-        borderRadius: '32px',
+        fontSize: '140px',
+        lineHeight: 1,
       }}>
-        {/* Diamond shape */}
-        <div style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          width: '80px',
-          height: '80px',
-          backgroundColor: '#2d5a27',
-          transform: 'rotate(45deg)',
-        }}>
-          <div style={{
-            display: 'flex',
-            width: '36px',
-            height: '36px',
-            borderRadius: '50%',
-            backgroundColor: '#ffffff',
-            transform: 'rotate(-45deg)',
-          }} />
-        </div>
+        ⚾
       </div>
     ),
     { ...size },

--- a/app/icon.js
+++ b/app/icon.js
@@ -12,16 +12,10 @@ export default function Icon() {
         justifyContent: 'center',
         width: '100%',
         height: '100%',
-        backgroundColor: '#1a2f16',
-        borderRadius: '4px',
+        fontSize: '28px',
+        lineHeight: 1,
       }}>
-        <div style={{
-          display: 'flex',
-          width: '20px',
-          height: '20px',
-          borderRadius: '50%',
-          backgroundColor: '#ffffff',
-        }} />
+        ⚾
       </div>
     ),
     { ...size },

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,8 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-  <rect width="64" height="64" fill="#1a2f16" rx="8"/>
-  <path d="M32 12 L52 32 L32 52 L12 32 Z" fill="none" stroke="#2d5a27" stroke-width="3"/>
-  <path d="M32 16 L48 32 L32 48 L16 32 Z" fill="#2d5a27"/>
-  <circle cx="32" cy="32" r="6" fill="#ffffff"/>
-  <path d="M29 28 Q32 26 35 28" fill="none" stroke="#1a2f16" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M29 36 Q32 38 35 36" fill="none" stroke="#1a2f16" stroke-width="1.5" stroke-linecap="round"/>
+  <text x="32" y="32" font-size="56" text-anchor="middle" dominant-baseline="central">⚾</text>
 </svg>


### PR DESCRIPTION
## Summary
- Replace custom-drawn green diamond/circle icons with the ⚾ baseball emoji
- Updated browser favicon (`app/icon.js`), Apple touch icon (`app/apple-icon.js`), and SVG favicon (`public/favicon.svg`)
- No changes needed to `layout.js` or `manifest.json` — file paths unchanged

## Pre-Landing Review
No issues found.

## Test plan
- [x] All Jest tests pass (303 tests, 21 suites)
- [ ] Visual check: browser tab shows ⚾ emoji
- [ ] Visual check: Apple touch icon shows ⚾ emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)