### PR TITLE
feat: ambient soundtracks meta text and OG image

### DIFF
--- a/app/api/og/route.js
+++ b/app/api/og/route.js
@@ -325,6 +325,15 @@ function renderCountIndicator(label, count, total) {
 async function renderGenericImage() {
   // fonts loaded at module level
 
+  // Generate sine wave bars for ambient sound wave motif
+  const barCount = 48;
+  const bars = Array.from({ length: barCount }, (_, i) => {
+    const t = i / barCount;
+    // Composite sine waves for organic, ambient feel
+    const h = Math.abs(Math.sin(t * Math.PI * 3) * 0.7 + Math.sin(t * Math.PI * 7 + 1) * 0.3);
+    return Math.max(4, h * 60);
+  });
+
   return new ImageResponse(
     (
       <div style={{
@@ -349,8 +358,28 @@ async function renderGenericImage() {
           display: 'flex',
           fontSize: '28px',
           color: COLORS.whiteDim,
+          marginBottom: '32px',
         }}>
-          Live MLB Games
+          ambient soundtracks for the national pastime
+        </div>
+        {/* Sound wave motif */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+          height: '64px',
+        }}>
+          {bars.map((h, i) => (
+            <div
+              key={i}
+              style={{
+                width: '6px',
+                height: `${h}px`,
+                backgroundColor: COLORS.whiteFaint,
+                borderRadius: '3px',
+              }}
+            />
+          ))}
         </div>
       </div>
     ),

--- a/app/layout.js
+++ b/app/layout.js
@@ -11,7 +11,7 @@ export const metadata = {
     default: 'Baseball Scores',
     template: '%s',
   },
-  description: 'Live MLB baseball scores with generative ambient music.',
+  description: 'ambient soundtracks for the national pastime',
   manifest: '/manifest.json',
   icons: {
     icon: '/favicon.svg',

--- a/app/page.js
+++ b/app/page.js
@@ -1,16 +1,16 @@
 import HomeClient from '../src/components/HomeClient';
 
 export const metadata = {
-  title: 'Baseball Scores | Live MLB Games',
-  description: 'Live MLB baseball scores with generative ambient music. Track every game in real time.',
+  title: 'Baseball Scores | ambient soundtracks for the national pastime',
+  description: 'ambient soundtracks for the national pastime',
   openGraph: {
-    title: 'Baseball Scores | Live MLB Games',
-    description: 'Live MLB baseball scores with generative ambient music.',
+    title: 'Baseball Scores | ambient soundtracks for the national pastime',
+    description: 'ambient soundtracks for the national pastime',
     images: [{ url: '/api/og', width: 1200, height: 630 }],
   },
   twitter: {
-    title: 'Baseball Scores | Live MLB Games',
-    description: 'Live MLB baseball scores with generative ambient music.',
+    title: 'Baseball Scores | ambient soundtracks for the national pastime',
+    description: 'ambient soundtracks for the national pastime',
     images: ['/api/og'],
   },
 };


### PR DESCRIPTION
## Summary
- Replace all "Live MLB Games" meta text with "ambient soundtracks for the national pastime"
- Update description, OG, and Twitter meta tags across layout and home page
- Update generic OG image subtitle and add sine wave visualization motif

## Pre-Landing Review
No issues found.

## Test plan
- [x] All Jest tests pass (303 tests, 0 failures)
- [ ] Visit `/api/og` to verify generic OG image renders with new tagline + wave motif
- [ ] Visit `/api/og?gameId=<id>` to confirm game cards still render correctly
- [ ] Check page source of `/` for correct meta tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)