### PR TITLE
fix: prevent scroll jank on mobile game selection

### DIFF
--- a/src/components/GameCard.js
+++ b/src/components/GameCard.js
@@ -24,7 +24,10 @@ const cardStyles = {
   },
   live: {
     cursor: 'pointer',
-    transition: 'all 0.3s ease',
+    transition: 'filter 0.3s ease, opacity 0.3s ease',
+    '@media (max-width: 600px)': {
+      transition: 'box-shadow 0.3s ease, opacity 0.3s ease',
+    },
     '&:hover': {
       borderColor: 'white',
       filter: 'drop-shadow(15px 10px 5px rgba(255, 255, 255, 0.45))',

--- a/src/components/MainLayout.js
+++ b/src/components/MainLayout.js
@@ -45,10 +45,10 @@ const MainLayout = ({ gameId }) => {
 
     if (activeGameId === String(id)) {
       setActiveGame(null);
-      router.replace('/');
+      router.replace('/', { scroll: false });
     } else {
       setActiveGame(id);
-      router.replace(`/${id}`);
+      router.replace(`/${id}`, { scroll: false });
     }
   }, [activeGameId, games, setActiveGame, router]);
 
@@ -56,13 +56,13 @@ const MainLayout = ({ gameId }) => {
   useEffect(() => {
     if (activeGameId && games[activeGameId]?.status !== 'Live' && Object.keys(games).length > 0) {
       setActiveGame(null);
-      router.replace('/');
+      router.replace('/', { scroll: false });
     }
   }, [games, activeGameId, setActiveGame, router]);
 
   const goToDashboard = useCallback(() => {
     setActiveGame(null);
-    router.push('/');
+    router.push('/', { scroll: false });
   }, [setActiveGame, router]);
 
   const handleContainerClick = useCallback((e) => {
@@ -71,7 +71,7 @@ const MainLayout = ({ gameId }) => {
     const closestHeader = e.target.closest('h1');
     if (!closestCard && !closestHeader) {
       setActiveGame(null);
-      router.replace('/');
+      router.replace('/', { scroll: false });
     }
   }, [activeGameId, setActiveGame, router]);
 


### PR DESCRIPTION
## Summary
- Add `{ scroll: false }` to all `router.replace()` and `router.push()` calls to prevent Next.js from resetting scroll position during game select/deselect
- Narrow CSS `transition: 'all 0.3s ease'` to only `filter`/`opacity` (desktop) and `box-shadow`/`opacity` (mobile) to avoid layout-triggering animations

## Pre-Landing Review
No issues found.

## Test plan
- [ ] On mobile: select a game, verify scroll position stays put
- [ ] Deselect a game, verify no scroll jump
- [ ] Verify shadow hover/select transitions still animate smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)