### PR TITLE
fix: resilient mobile audio init with AudioContext resume

### DIFF
--- a/src/audio/engine.js
+++ b/src/audio/engine.js
@@ -100,4 +100,12 @@ export class AudioEngine {
   isConnected() {
     return this.connected;
   }
+
+  async ensureRunning() {
+    if (!this.connected) return;
+    const ctx = Tone.getContext().rawContext;
+    if (ctx.state === 'suspended') {
+      await ctx.resume();
+    }
+  }
 }

--- a/src/audio/engine.test.js
+++ b/src/audio/engine.test.js
@@ -10,7 +10,7 @@ jest.mock('tone', () => ({
     dispose: jest.fn(),
   })),
   getContext: jest.fn(() => ({
-    rawContext: { close: jest.fn() },
+    rawContext: { close: jest.fn(), state: 'running', resume: jest.fn().mockResolvedValue(undefined) },
   })),
   now: jest.fn(() => 0),
 }));
@@ -158,5 +158,34 @@ describe('AudioEngine', () => {
 
     engine.setMasterVolume(0.5);
     expect(engine.masterGain.gain.value).toBe(0.5);
+  });
+
+  // --- ensureRunning ---
+
+  test('ensureRunning does not call resume when context is running', async () => {
+    const mockResume = jest.fn();
+    Tone.getContext.mockReturnValue({ rawContext: { state: 'running', resume: mockResume, close: jest.fn() } });
+
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    await engine.ensureRunning();
+    expect(mockResume).not.toHaveBeenCalled();
+  });
+
+  test('ensureRunning calls resume when context is suspended', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    const mockCtx = { state: 'suspended', resume: jest.fn().mockResolvedValue(undefined), close: jest.fn() };
+    Tone.getContext.mockReturnValue({ rawContext: mockCtx });
+
+    await engine.ensureRunning();
+    expect(mockCtx.resume).toHaveBeenCalled();
+  });
+
+  test('ensureRunning is a no-op when not connected', async () => {
+    await engine.ensureRunning(); // should not throw
+    expect(Tone.getContext).not.toHaveBeenCalled();
   });
 });

--- a/src/audio/index.js
+++ b/src/audio/index.js
@@ -29,3 +29,7 @@ export function setMasterVolume(v) {
 export function isConnected() {
   return engine?.isConnected() ?? false;
 }
+
+export async function ensureRunning() {
+  return engine?.ensureRunning();
+}

--- a/src/components/MainLayout.js
+++ b/src/components/MainLayout.js
@@ -28,6 +28,17 @@ const MainLayout = ({ gameId }) => {
     return () => window.removeEventListener('beforeunload', cleanup);
   }, []);
 
+  // Resume AudioContext when returning from background (iOS suspends it)
+  useEffect(() => {
+    const handleVisibility = async () => {
+      if (document.visibilityState === 'visible' && audio.isConnected()) {
+        try { await audio.ensureRunning(); } catch (_) {}
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, []);
+
   // Sync URL gameId with store
   useEffect(() => {
     setActiveGame(gameId || null);
@@ -39,8 +50,14 @@ const MainLayout = ({ gameId }) => {
     if (games[id]?.status !== 'Live') return;
 
     // Connect audio on first interaction (user gesture satisfies AudioContext requirement)
-    if (!audio.isConnected()) {
-      await audio.connect(useGameStore);
+    // ensureRunning() resumes the context if iOS suspended it in the background
+    try {
+      if (!audio.isConnected()) {
+        await audio.connect(useGameStore);
+      }
+      await audio.ensureRunning();
+    } catch (err) {
+      console.warn('Audio failed to start:', err);
     }
 
     if (activeGameId === String(id)) {

--- a/src/components/__tests__/MainLayout.test.js
+++ b/src/components/__tests__/MainLayout.test.js
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MainLayout from '../MainLayout';
+import { useGameStore } from '../../store/gameStore';
+import * as audio from '../../audio';
+
+// --- Mocks ---
+
+jest.mock('../../audio', () => ({
+  connect: jest.fn().mockResolvedValue(undefined),
+  disconnect: jest.fn(),
+  ensureRunning: jest.fn().mockResolvedValue(undefined),
+  isConnected: jest.fn().mockReturnValue(false),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  setMasterVolume: jest.fn(),
+}));
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
+}));
+
+jest.mock('../../hooks/useGamePolling', () => ({
+  useGamePolling: jest.fn(),
+}));
+
+jest.mock('../../hooks/useLiveGamePolling', () => ({
+  useLiveGamePolling: jest.fn(),
+}));
+
+const liveGame = {
+  gamePk: 1,
+  gameId: '1',
+  status: 'Live',
+  gameDate: '2025-04-15T23:10:00Z',
+  awayTeam: { id: 2, name: 'Red Sox', abbreviation: 'BOS' },
+  homeTeam: { id: 1, name: 'Yankees', abbreviation: 'NYY' },
+  awayScore: 0,
+  homeScore: 0,
+  inning: 1,
+  isTopInning: true,
+  inningState: 'Top',
+  balls: 0,
+  strikes: 0,
+  outs: 0,
+  runners: [false, false, false],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useGameStore.setState({
+    games: { '1': liveGame },
+    activeGameId: null,
+    lastAcceptedSeq: 0,
+    lastUpdatedAt: null,
+    pollError: null,
+  });
+});
+
+describe('MainLayout audio integration', () => {
+  test('handleGameSelect calls audio.connect + ensureRunning on first tap', async () => {
+    audio.isConnected.mockReturnValue(false);
+
+    render(<MainLayout />);
+    const card = screen.getByText('Red Sox').closest('.MuiCard-root');
+
+    await act(async () => {
+      fireEvent.click(card);
+    });
+
+    expect(audio.connect).toHaveBeenCalled();
+    expect(audio.ensureRunning).toHaveBeenCalled();
+  });
+
+  test('handleGameSelect still selects game when audio.connect throws', async () => {
+    audio.isConnected.mockReturnValue(false);
+    audio.connect.mockRejectedValueOnce(new Error('AudioContext not allowed'));
+
+    render(<MainLayout />);
+    const card = screen.getByText('Red Sox').closest('.MuiCard-root');
+
+    await act(async () => {
+      fireEvent.click(card);
+    });
+
+    // Game should still be selected despite audio failure
+    expect(useGameStore.getState().activeGameId).toBe('1');
+  });
+
+  test('handleGameSelect calls ensureRunning (not connect) on subsequent taps', async () => {
+    audio.isConnected.mockReturnValue(true);
+
+    render(<MainLayout />);
+    const card = screen.getByText('Red Sox').closest('.MuiCard-root');
+
+    await act(async () => {
+      fireEvent.click(card);
+    });
+
+    expect(audio.connect).not.toHaveBeenCalled();
+    expect(audio.ensureRunning).toHaveBeenCalled();
+  });
+
+  test('visibilitychange resumes audio when connected', async () => {
+    audio.isConnected.mockReturnValue(true);
+
+    render(<MainLayout />);
+
+    await act(async () => {
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(audio.ensureRunning).toHaveBeenCalled();
+  });
+
+  test('visibilitychange does nothing when not connected', async () => {
+    audio.isConnected.mockReturnValue(false);
+
+    render(<MainLayout />);
+
+    await act(async () => {
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(audio.ensureRunning).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `ensureRunning()` method to AudioEngine that checks `AudioContext.state` and calls `resume()` if suspended by the OS (common on iOS Safari background/foreground)
- Wrap audio initialization in try/catch so failures never block game selection
- Add `visibilitychange` listener to automatically resume audio when tab returns to foreground
- Add MainLayout component tests covering audio connect, error recovery, and visibility handling

## Pre-Landing Review
No issues found.

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] All Jest tests pass (311 tests, 0 failures)
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)