### PR TITLE
feat: mobile background audio with keep-alive and lock screen controls

### DIFF
--- a/src/audio/engine.js
+++ b/src/audio/engine.js
@@ -1,6 +1,7 @@
 import * as Tone from 'tone';
 import { diffGameEvents } from './diffGameEvents';
 import { Composer } from './composer';
+import { startKeepAlive, stopKeepAlive, updateMediaSession, ensureKeepAlive } from './keepAlive';
 
 let instance = null;
 
@@ -28,6 +29,14 @@ export class AudioEngine {
       this.composer = new Composer(this.masterGain);
       this.connected = true;
 
+      // Best-effort: silent audio keep-alive + Media Session + Wake Lock
+      try {
+        await startKeepAlive({
+          onPlay: () => this.resume(),
+          onPause: () => this.pause(),
+        });
+      } catch (_) { /* keep-alive is optional */ }
+
       // Snapshot initial active game
       const state = store.getState();
       this.prevGame = state.activeGameId
@@ -44,6 +53,14 @@ export class AudioEngine {
           const events = diffGameEvents(this.prevGame, nextGame);
           this.composer.update(nextGame, events);
           this.prevGame = nextGame;
+
+          // Update lock screen metadata with current matchup
+          if (nextGame) {
+            updateMediaSession({
+              title: `${nextGame.awayTeam.abbreviation} @ ${nextGame.homeTeam.abbreviation}`,
+              artist: 'Baseball Scores',
+            });
+          }
         }
       });
     } catch (err) {
@@ -72,6 +89,7 @@ export class AudioEngine {
     this.prevGame = null;
     this._paused = false;
     instance = null;
+    stopKeepAlive();
   }
 
   pause() {
@@ -79,6 +97,7 @@ export class AudioEngine {
       this._paused = true;
       this.masterGain.gain.value = 0;
       this.composer?.suspend();
+      updateMediaSession({ isPlaying: false });
     }
   }
 
@@ -87,6 +106,7 @@ export class AudioEngine {
       this._paused = false;
       this.masterGain.gain.value = this._volume;
       this.composer?.resume();
+      updateMediaSession({ isPlaying: true });
     }
   }
 
@@ -107,5 +127,6 @@ export class AudioEngine {
     if (ctx.state === 'suspended') {
       await ctx.resume();
     }
+    await ensureKeepAlive();
   }
 }

--- a/src/audio/engine.test.js
+++ b/src/audio/engine.test.js
@@ -25,8 +25,17 @@ jest.mock('./composer', () => ({
   })),
 }));
 
+// Mock keepAlive
+jest.mock('./keepAlive', () => ({
+  startKeepAlive: jest.fn().mockResolvedValue(undefined),
+  stopKeepAlive: jest.fn(),
+  updateMediaSession: jest.fn(),
+  ensureKeepAlive: jest.fn().mockResolvedValue(undefined),
+}));
+
 const Tone = require('tone');
 const { Composer } = require('./composer');
+const { startKeepAlive, stopKeepAlive, updateMediaSession, ensureKeepAlive } = require('./keepAlive');
 
 describe('AudioEngine', () => {
   let engine;
@@ -187,5 +196,79 @@ describe('AudioEngine', () => {
   test('ensureRunning is a no-op when not connected', async () => {
     await engine.ensureRunning(); // should not throw
     expect(Tone.getContext).not.toHaveBeenCalled();
+  });
+
+  // --- Keep-alive integration ---
+
+  test('connect calls startKeepAlive with play/pause callbacks', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    expect(startKeepAlive).toHaveBeenCalledWith({
+      onPlay: expect.any(Function),
+      onPause: expect.any(Function),
+    });
+  });
+
+  test('disconnect calls stopKeepAlive', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    engine.disconnect();
+
+    expect(stopKeepAlive).toHaveBeenCalled();
+  });
+
+  test('ensureRunning calls ensureKeepAlive', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    await engine.ensureRunning();
+
+    expect(ensureKeepAlive).toHaveBeenCalled();
+  });
+
+  test('pause updates media session playback state', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    engine.pause();
+
+    expect(updateMediaSession).toHaveBeenCalledWith({ isPlaying: false });
+  });
+
+  test('resume updates media session playback state', async () => {
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    engine.pause();
+    engine.resume();
+
+    expect(updateMediaSession).toHaveBeenCalledWith({ isPlaying: true });
+  });
+
+  test('updates media session with team names on game change', async () => {
+    const game1 = makeGame({ homeScore: 0 });
+    const game2 = makeGame({ homeScore: 1 });
+
+    const store = createMockStore({ activeGameId: '1', games: { '1': game1 } });
+    await engine.connect(store);
+
+    updateMediaSession.mockClear();
+    store.setState({ games: { '1': game2 } });
+
+    expect(updateMediaSession).toHaveBeenCalledWith({
+      title: 'BOS @ NYY',
+      artist: 'Baseball Scores',
+    });
+  });
+
+  test('connect succeeds even if startKeepAlive throws', async () => {
+    startKeepAlive.mockRejectedValueOnce(new Error('keep-alive failed'));
+
+    const store = createMockStore({ activeGameId: null, games: {} });
+    await engine.connect(store);
+
+    expect(engine.isConnected()).toBe(true);
   });
 });

--- a/src/audio/keepAlive.js
+++ b/src/audio/keepAlive.js
@@ -1,0 +1,199 @@
+/**
+ * Keep-alive module for mobile background audio.
+ *
+ * Three mechanisms work together:
+ * 1. Silent <audio> loop — browsers treat pages with playing <audio> as
+ *    "media pages" and are less aggressive about suspending AudioContext
+ * 2. Media Session API — lock screen controls (play/pause) and metadata
+ * 3. Wake Lock API — prevents screen dimming while audio plays
+ *
+ * All functions are best-effort — failures are silent.
+ * Tone.js audio works without this module.
+ */
+
+let audioEl = null;
+let wakeLock = null;
+let visibilityHandler = null;
+
+/**
+ * Generate a minimal silent WAV as a Blob URL.
+ * 44-byte header + 1 second of silence (44100 samples, mono, 16-bit, 44100 Hz).
+ */
+function createSilentWavUrl() {
+  const sampleRate = 44100;
+  const numSamples = sampleRate; // 1 second of silence
+  const dataSize = numSamples * 2; // 16-bit = 2 bytes per sample
+  const fileSize = 44 + dataSize;
+
+  const buffer = new ArrayBuffer(fileSize);
+  const view = new DataView(buffer);
+
+  // RIFF header
+  writeString(view, 0, 'RIFF');
+  view.setUint32(4, fileSize - 8, true);
+  writeString(view, 8, 'WAVE');
+
+  // fmt chunk
+  writeString(view, 12, 'fmt ');
+  view.setUint32(16, 16, true);       // chunk size
+  view.setUint16(20, 1, true);        // PCM format
+  view.setUint16(22, 1, true);        // mono
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true); // byte rate
+  view.setUint16(32, 2, true);        // block align
+  view.setUint16(34, 16, true);       // bits per sample
+
+  // data chunk (all zeros = silence)
+  writeString(view, 36, 'data');
+  view.setUint32(40, dataSize, true);
+  // Samples are already 0 (silence) from ArrayBuffer initialization
+
+  const blob = new Blob([buffer], { type: 'audio/wav' });
+  return URL.createObjectURL(blob);
+}
+
+function writeString(view, offset, str) {
+  for (let i = 0; i < str.length; i++) {
+    view.setUint8(offset + i, str.charCodeAt(i));
+  }
+}
+
+/**
+ * Request a screen wake lock (best-effort).
+ * Returns the WakeLockSentinel or null.
+ */
+async function requestWakeLock() {
+  try {
+    if ('wakeLock' in navigator) {
+      return await navigator.wakeLock.request('screen');
+    }
+  } catch (_) { /* user denied or not supported */ }
+  return null;
+}
+
+/**
+ * Start the keep-alive system: silent audio loop, Media Session, Wake Lock.
+ * Must be called within a user gesture context for autoplay to succeed.
+ *
+ * @param {{ onPlay: Function, onPause: Function }} callbacks
+ */
+export async function startKeepAlive(callbacks = {}) {
+  // Silent audio loop
+  try {
+    if (!audioEl) {
+      const url = createSilentWavUrl();
+      audioEl = document.createElement('audio');
+      audioEl.src = url;
+      audioEl.loop = true;
+      await audioEl.play();
+    }
+  } catch (_) { /* autoplay blocked — keep-alive won't work but audio still plays */ }
+
+  // Media Session
+  try {
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: 'Baseball Scores',
+        artist: 'Ambient Soundtrack',
+      });
+      navigator.mediaSession.playbackState = 'playing';
+
+      if (callbacks.onPlay) {
+        navigator.mediaSession.setActionHandler('play', callbacks.onPlay);
+      }
+      if (callbacks.onPause) {
+        navigator.mediaSession.setActionHandler('pause', callbacks.onPause);
+      }
+    }
+  } catch (_) { /* Media Session not supported */ }
+
+  // Wake Lock
+  wakeLock = await requestWakeLock();
+
+  // Re-acquire wake lock when returning from background (browsers release it)
+  if (!visibilityHandler) {
+    visibilityHandler = async () => {
+      if (document.visibilityState === 'visible' && !wakeLock) {
+        wakeLock = await requestWakeLock();
+      }
+    };
+    document.addEventListener('visibilitychange', visibilityHandler);
+  }
+}
+
+/**
+ * Stop everything: pause and remove <audio>, clear Media Session, release Wake Lock.
+ */
+export function stopKeepAlive() {
+  // Audio element
+  if (audioEl) {
+    audioEl.pause();
+    if (audioEl.src) {
+      URL.revokeObjectURL(audioEl.src);
+    }
+    audioEl.remove();
+    audioEl = null;
+  }
+
+  // Media Session
+  try {
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.metadata = null;
+      navigator.mediaSession.playbackState = 'none';
+      navigator.mediaSession.setActionHandler('play', null);
+      navigator.mediaSession.setActionHandler('pause', null);
+    }
+  } catch (_) { /* ignore */ }
+
+  // Wake Lock
+  if (wakeLock) {
+    try { wakeLock.release(); } catch (_) { /* already released */ }
+    wakeLock = null;
+  }
+
+  // Visibility handler
+  if (visibilityHandler) {
+    document.removeEventListener('visibilitychange', visibilityHandler);
+    visibilityHandler = null;
+  }
+}
+
+/**
+ * Update Media Session metadata and/or playback state.
+ *
+ * @param {{ title?: string, artist?: string, isPlaying?: boolean }} opts
+ */
+export function updateMediaSession(opts = {}) {
+  try {
+    if (!('mediaSession' in navigator)) return;
+
+    if (opts.title || opts.artist) {
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: opts.title ?? 'Baseball Scores',
+        artist: opts.artist ?? 'Ambient Soundtrack',
+      });
+    }
+
+    if (opts.isPlaying !== undefined) {
+      navigator.mediaSession.playbackState = opts.isPlaying ? 'playing' : 'paused';
+    }
+  } catch (_) { /* ignore */ }
+}
+
+/**
+ * Ensure the keep-alive <audio> is still playing and wake lock is held.
+ * Called from ensureRunning() when returning from background.
+ */
+export async function ensureKeepAlive() {
+  // Re-play audio if browser paused it
+  try {
+    if (audioEl && audioEl.paused) {
+      await audioEl.play();
+    }
+  } catch (_) { /* autoplay blocked */ }
+
+  // Re-acquire wake lock if lost
+  if (!wakeLock) {
+    wakeLock = await requestWakeLock();
+  }
+}

--- a/src/audio/keepAlive.test.js
+++ b/src/audio/keepAlive.test.js
@@ -1,0 +1,266 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// Reset module state between tests
+let keepAlive;
+
+beforeEach(async () => {
+  jest.resetModules();
+
+  // Mock Audio element
+  const mockPlay = jest.fn().mockResolvedValue(undefined);
+  const mockPause = jest.fn();
+  const mockRemove = jest.fn();
+
+  jest.spyOn(document, 'createElement').mockImplementation((tag) => {
+    if (tag === 'audio') {
+      return {
+        play: mockPlay,
+        pause: mockPause,
+        remove: mockRemove,
+        paused: false,
+        loop: false,
+        src: '',
+      };
+    }
+    return document._createElement(tag);
+  });
+
+  // Mock URL.createObjectURL / revokeObjectURL
+  global.URL.createObjectURL = jest.fn(() => 'blob:silent-wav');
+  global.URL.revokeObjectURL = jest.fn();
+
+  // Mock MediaMetadata
+  global.MediaMetadata = jest.fn().mockImplementation((opts) => opts);
+
+  keepAlive = await import('./keepAlive');
+});
+
+afterEach(() => {
+  keepAlive.stopKeepAlive();
+  jest.restoreAllMocks();
+  delete navigator.mediaSession;
+  delete navigator.wakeLock;
+});
+
+// Helper to set up mediaSession mock
+function setupMediaSession() {
+  const handlers = {};
+  Object.defineProperty(navigator, 'mediaSession', {
+    value: {
+      metadata: null,
+      playbackState: 'none',
+      setActionHandler: jest.fn((action, handler) => {
+        handlers[action] = handler;
+      }),
+    },
+    writable: true,
+    configurable: true,
+  });
+  return handlers;
+}
+
+// Helper to set up wakeLock mock
+function setupWakeLock() {
+  const sentinel = { release: jest.fn() };
+  Object.defineProperty(navigator, 'wakeLock', {
+    value: { request: jest.fn().mockResolvedValue(sentinel) },
+    writable: true,
+    configurable: true,
+  });
+  return sentinel;
+}
+
+describe('keepAlive', () => {
+  // --- startKeepAlive ---
+
+  test('creates audio element and calls play()', async () => {
+    await keepAlive.startKeepAlive();
+
+    expect(document.createElement).toHaveBeenCalledWith('audio');
+    const audioEl = document.createElement.mock.results.find(
+      r => r.type === 'return' && r.value.loop !== undefined
+    ).value;
+    expect(audioEl.loop).toBe(true);
+    expect(audioEl.src).toBe('blob:silent-wav');
+    expect(audioEl.play).toHaveBeenCalled();
+  });
+
+  test('is idempotent — second call does not create another audio element', async () => {
+    await keepAlive.startKeepAlive();
+    const createCount = document.createElement.mock.calls.filter(c => c[0] === 'audio').length;
+
+    await keepAlive.startKeepAlive();
+    const createCount2 = document.createElement.mock.calls.filter(c => c[0] === 'audio').length;
+
+    expect(createCount2).toBe(createCount);
+  });
+
+  test('registers Media Session metadata and handlers', async () => {
+    const handlers = setupMediaSession();
+    const onPlay = jest.fn();
+    const onPause = jest.fn();
+
+    await keepAlive.startKeepAlive({ onPlay, onPause });
+
+    expect(navigator.mediaSession.metadata).toEqual({
+      title: 'Baseball Scores',
+      artist: 'Ambient Soundtrack',
+    });
+    expect(navigator.mediaSession.playbackState).toBe('playing');
+    expect(navigator.mediaSession.setActionHandler).toHaveBeenCalledWith('play', onPlay);
+    expect(navigator.mediaSession.setActionHandler).toHaveBeenCalledWith('pause', onPause);
+  });
+
+  test('Media Session play handler calls onPlay callback', async () => {
+    const handlers = setupMediaSession();
+    const onPlay = jest.fn();
+
+    await keepAlive.startKeepAlive({ onPlay, onPause: jest.fn() });
+    handlers.play();
+
+    expect(onPlay).toHaveBeenCalled();
+  });
+
+  test('Media Session pause handler calls onPause callback', async () => {
+    const handlers = setupMediaSession();
+    const onPause = jest.fn();
+
+    await keepAlive.startKeepAlive({ onPlay: jest.fn(), onPause });
+    handlers.pause();
+
+    expect(onPause).toHaveBeenCalled();
+  });
+
+  test('requests wake lock when API is available', async () => {
+    const sentinel = setupWakeLock();
+
+    await keepAlive.startKeepAlive();
+
+    expect(navigator.wakeLock.request).toHaveBeenCalledWith('screen');
+  });
+
+  test('works without mediaSession API', async () => {
+    // navigator.mediaSession is undefined by default in jsdom
+    await expect(keepAlive.startKeepAlive()).resolves.not.toThrow();
+  });
+
+  test('works without wakeLock API', async () => {
+    // navigator.wakeLock is undefined by default in jsdom
+    await expect(keepAlive.startKeepAlive()).resolves.not.toThrow();
+  });
+
+  // --- stopKeepAlive ---
+
+  test('pauses and removes audio element', async () => {
+    await keepAlive.startKeepAlive();
+
+    const audioEl = document.createElement.mock.results.find(
+      r => r.type === 'return' && r.value.loop !== undefined
+    ).value;
+
+    keepAlive.stopKeepAlive();
+
+    expect(audioEl.pause).toHaveBeenCalled();
+    expect(audioEl.remove).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:silent-wav');
+  });
+
+  test('clears Media Session on stop', async () => {
+    setupMediaSession();
+    await keepAlive.startKeepAlive({ onPlay: jest.fn(), onPause: jest.fn() });
+
+    keepAlive.stopKeepAlive();
+
+    expect(navigator.mediaSession.metadata).toBeNull();
+    expect(navigator.mediaSession.playbackState).toBe('none');
+    expect(navigator.mediaSession.setActionHandler).toHaveBeenCalledWith('play', null);
+    expect(navigator.mediaSession.setActionHandler).toHaveBeenCalledWith('pause', null);
+  });
+
+  test('releases wake lock on stop', async () => {
+    const sentinel = setupWakeLock();
+    await keepAlive.startKeepAlive();
+
+    keepAlive.stopKeepAlive();
+
+    expect(sentinel.release).toHaveBeenCalled();
+  });
+
+  test('stopKeepAlive is safe to call without start', () => {
+    expect(() => keepAlive.stopKeepAlive()).not.toThrow();
+  });
+
+  // --- updateMediaSession ---
+
+  test('updates title and artist', async () => {
+    setupMediaSession();
+    await keepAlive.startKeepAlive();
+
+    keepAlive.updateMediaSession({ title: 'NYY @ BOS', artist: 'Baseball Scores' });
+
+    expect(navigator.mediaSession.metadata).toEqual({
+      title: 'NYY @ BOS',
+      artist: 'Baseball Scores',
+    });
+  });
+
+  test('updates playback state', async () => {
+    setupMediaSession();
+    await keepAlive.startKeepAlive();
+
+    keepAlive.updateMediaSession({ isPlaying: false });
+    expect(navigator.mediaSession.playbackState).toBe('paused');
+
+    keepAlive.updateMediaSession({ isPlaying: true });
+    expect(navigator.mediaSession.playbackState).toBe('playing');
+  });
+
+  test('updateMediaSession is safe without mediaSession API', () => {
+    expect(() => keepAlive.updateMediaSession({ title: 'test' })).not.toThrow();
+  });
+
+  // --- ensureKeepAlive ---
+
+  test('re-plays audio if browser paused it', async () => {
+    await keepAlive.startKeepAlive();
+
+    const audioEl = document.createElement.mock.results.find(
+      r => r.type === 'return' && r.value.loop !== undefined
+    ).value;
+
+    // Simulate browser pausing the audio
+    audioEl.paused = true;
+    audioEl.play.mockClear();
+
+    await keepAlive.ensureKeepAlive();
+
+    expect(audioEl.play).toHaveBeenCalled();
+  });
+
+  test('re-acquires wake lock if lost', async () => {
+    const sentinel = setupWakeLock();
+    await keepAlive.startKeepAlive();
+
+    // Simulate wake lock being released by browser
+    keepAlive.stopKeepAlive();
+    await keepAlive.startKeepAlive(); // restart without wake lock setup
+    navigator.wakeLock.request.mockClear();
+
+    // Force internal wakeLock to null by stopping and restarting without wakeLock API
+    keepAlive.stopKeepAlive();
+    delete navigator.wakeLock;
+    await keepAlive.startKeepAlive();
+
+    // Now add wakeLock back and ensure it re-acquires
+    setupWakeLock();
+    await keepAlive.ensureKeepAlive();
+
+    expect(navigator.wakeLock.request).toHaveBeenCalledWith('screen');
+  });
+
+  test('ensureKeepAlive is safe without prior start', async () => {
+    await expect(keepAlive.ensureKeepAlive()).resolves.not.toThrow();
+  });
+});

--- a/src/components/MainLayout.js
+++ b/src/components/MainLayout.js
@@ -32,6 +32,8 @@ const MainLayout = ({ gameId }) => {
   useEffect(() => {
     const handleVisibility = async () => {
       if (document.visibilityState === 'visible' && audio.isConnected()) {
+        // Small delay — iOS Safari needs a moment before AudioContext.resume() succeeds
+        await new Promise(r => setTimeout(r, 100));
         try { await audio.ensureRunning(); } catch (_) {}
       }
     };

--- a/src/components/__tests__/MainLayout.test.js
+++ b/src/components/__tests__/MainLayout.test.js
@@ -105,28 +105,37 @@ describe('MainLayout audio integration', () => {
   });
 
   test('visibilitychange resumes audio when connected', async () => {
+    jest.useFakeTimers();
     audio.isConnected.mockReturnValue(true);
 
     render(<MainLayout />);
 
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // Visibility handler waits 100ms before calling ensureRunning (iOS Safari workaround)
     await act(async () => {
-      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
-      document.dispatchEvent(new Event('visibilitychange'));
+      jest.advanceTimersByTime(100);
     });
 
     expect(audio.ensureRunning).toHaveBeenCalled();
+    jest.useRealTimers();
   });
 
   test('visibilitychange does nothing when not connected', async () => {
+    jest.useFakeTimers();
     audio.isConnected.mockReturnValue(false);
 
     render(<MainLayout />);
 
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
     await act(async () => {
-      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
-      document.dispatchEvent(new Event('visibilitychange'));
+      jest.advanceTimersByTime(100);
     });
 
     expect(audio.ensureRunning).not.toHaveBeenCalled();
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- Add silent `<audio>` loop keep-alive to prevent mobile browsers from suspending AudioContext when backgrounded
- Integrate Media Session API for lock screen play/pause controls and team matchup metadata (e.g. "BOS @ NYY")
- Add Wake Lock API to prevent screen dimming during playback
- Improve iOS Safari visibility handler with 100ms delay before AudioContext resume
- All mechanisms are best-effort with try/catch — failures don't break audio

## Pre-Landing Review
Pre-Landing Review: 1 issue (0 critical, 1 informational)

**Issues** (non-blocking):
- [keepAlive.js:19] Stale JSDoc comment — fixed in commit

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] All tests pass (23 suites, 336 tests)
- [x] Production build succeeds
- [ ] Manual: iOS Safari — play audio, lock screen, verify audio continues + lock screen controls
- [ ] Manual: Android Chrome — same flow
- [ ] Manual: screen stays on while audio plays (wake lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)