### PR TITLE
feat: boost overall audio volume ~6-8dB

### DIFF
--- a/src/audio/composer/effects.js
+++ b/src/audio/composer/effects.js
@@ -3,7 +3,7 @@
  * All layers route through this bus before reaching the master gain.
  *
  * Signal flow:
- *   voices → bus → saturation → tapeFilter (LP 4.8kHz) → Reverb → Compressor → makeupGain (+4dB) → Limiter (-1dB) → output
+ *   voices → bus → saturation → tapeFilter (LP 4.8kHz) → Reverb → Compressor → makeupGain (+8dB) → Limiter (-1dB) → output
  *   voices → delaySend → PingPongDelay → bus
  *
  * Saturation adds even harmonics (tape warmth).
@@ -40,14 +40,14 @@ export class EffectsChain {
 
     // Compressor: tighter glue — catches reverb tail buildup and EventVoice transients
     this.compressor = new Tone.Compressor({
-      threshold: -18,
+      threshold: -14,
       ratio: 3,
       attack: 0.03,
       release: 0.25,
     });
 
-    // Makeup gain: restore loudness lost from tighter compression (+4dB)
-    this.makeupGain = new Tone.Gain(1.58);
+    // Makeup gain: restore loudness lost from compression (+8dB)
+    this.makeupGain = new Tone.Gain(2.5);
 
     // Limiter: brickwall ceiling at -1dB (intersample peak margin for phone DACs/Bluetooth)
     this.limiter = new Tone.Limiter(-1);

--- a/src/audio/composer/effects.test.js
+++ b/src/audio/composer/effects.test.js
@@ -43,7 +43,7 @@ describe('EffectsChain', () => {
       'Filter',         // tapeFilter
       'Reverb',         // reverb
       'Compressor',     // compressor
-      'Gain(1.58)',     // makeupGain
+      'Gain(2.5)',      // makeupGain
       'Limiter',        // limiter
     ]);
     // Last node connects to output

--- a/src/audio/composer/layers/BreathLayer.js
+++ b/src/audio/composer/layers/BreathLayer.js
@@ -15,9 +15,9 @@
  */
 import * as Tone from 'tone';
 
-const BREATH_VOLUME = 0.055;
-const HISS_VOLUME = 0.02;
-const SURFACE_VOLUME = 0.012;
+const BREATH_VOLUME = 0.09;
+const HISS_VOLUME = 0.035;
+const SURFACE_VOLUME = 0.02;
 const CRACKLE_VOLUME = 0.04;
 const LFO_MIN_FREQ = 0.08;
 const LFO_MAX_FREQ = 0.125;

--- a/src/audio/composer/layers/EventVoice.js
+++ b/src/audio/composer/layers/EventVoice.js
@@ -47,7 +47,7 @@ export class EventVoice {
     });
 
     // Gain for volume control — events punctuate, not dominate
-    this.gain = new Tone.Gain(0.12);
+    this.gain = new Tone.Gain(0.22);
 
     // Wire: synths → gain → panner → output
     this.bellSynth.connect(this.gain);

--- a/src/audio/composer/layers/PadLayer.js
+++ b/src/audio/composer/layers/PadLayer.js
@@ -67,7 +67,7 @@ export class PadLayer {
     });
 
     // Volume control — pad sits underneath pulse pools
-    this.gain = new Tone.Gain(0.09);
+    this.gain = new Tone.Gain(0.18);
 
     // Wire: synth → vibrato → chorus → gain → panner → output
     this.synth.connect(this.vibrato);
@@ -128,7 +128,7 @@ export class PadLayer {
       this._startVoices(harmonyState.chordTones);
 
       // Fade in
-      this.gain.gain.rampTo(0.09, duration * 0.5);
+      this.gain.gain.rampTo(0.18, duration * 0.5);
 
       this._crossfading = false;
       this._resetIdleDrift();

--- a/src/audio/composer/layers/PulsePool.js
+++ b/src/audio/composer/layers/PulsePool.js
@@ -71,7 +71,7 @@ export class PulsePool {
     this.running = true;
 
     // Fade in
-    this.gain.gain.rampTo(0.09, fadeIn);
+    this.gain.gain.rampTo(0.18, fadeIn);
 
     // Start the loop
     this.loop.start(Tone.now());


### PR DESCRIPTION
## Summary
- Doubled layer gains across all four audio layers (pad, pulse, events, breath/texture) to address the audio being too quiet
- Raised makeup gain from +4dB to +8dB and compressor threshold from -18 to -14dB to preserve dynamics at higher levels
- The existing -1dB brickwall limiter prevents clipping — no structural changes needed

## Test plan
- [ ] Start dev server, click a game, confirm audio is noticeably louder
- [ ] Verify no audible distortion or clipping during busy game moments (multiple runners + events)
- [ ] Check that breath/vinyl texture layers remain subtle relative to pads and pulses

🤖 Generated with [Claude Code](https://claude.com/claude-code)